### PR TITLE
Created lib build script to transpile and convert svgs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,8 @@ test:
 	@$(MAKE) lint
 	@$(MAKE) unit
 
+build:
+	@npm run --silent build
+
 show-coverage:
 	@open coverage/PhantomJS*/index.html

--- a/bin/build-lib.js
+++ b/bin/build-lib.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright (c) 2016, Globo.com (https://github.com/globocom)
+ *
+ * License: MIT
+ */
+
+var rimraf = require('rimraf');
+var execSync = require('child_process').execSync;
+var fs = require('fs');
+
+var NODE_MODULES = 'node_modules/.bin/';
+
+function run (cmd) {
+  console.log('-> ' + cmd);
+  return execSync(NODE_MODULES + cmd, {stdio: [0, 1, 2]});
+}
+
+console.log('# Cleaning up lib/');
+rimraf.sync('lib/');
+
+console.log('# Transpiling source');
+run('babel --copy-files -d lib/ src/');
+
+console.log('# Converting SVG to React');
+run('svg2react lib/icons/*');
+
+console.log('# Transpiling icons');
+run('babel -d ./ lib/icons/*.react.js');
+
+console.log('# Renaming icons to original import names');
+var file, fullPath, newName;
+var files = fs.readdirSync('lib/icons');
+for (var i = 0; i < files.length; i++) {
+  file = files[i];
+  if (!file.endsWith('.react.js')) {
+    continue;
+  }
+
+  fullPath = 'lib/icons/' + file;
+  newName = fullPath.replace('.react.js', '');
+
+  console.log(fullPath, '->', newName);
+
+  fs.renameSync(fullPath, newName);
+}
+
+console.log('# Building lib: done!');

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test": "babel-node node_modules/isparta/bin/isparta cover karma -- start",
     "test:mocha": "mocha --opts mocha.opts -- tests/*_test.js",
     "test:watch": "mocha -w --opts mocha.opts -- tests/*_test.js",
-    "build:lib": "rimraf lib && babel -d lib/ src/",
+    "build:lib": "./bin/build-lib.js",
     "build:dist": "rimraf dist && webpack --config webpack.config.dist.js --optimize-minimize",
     "build": "npm run build:lib && npm run build:dist",
     "site": "webpack --config webpack.config.site.js --optimize-minimize",


### PR DESCRIPTION
Fixes #10.

The process involved is:

* Transpile source using `babel`
* Convert SVGs to React using `svg2react`
* Transpile icons using `babel`
* Move icons to their original filenames