### PR TITLE
Fixed toolbar position when applying link

### DIFF
--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -150,9 +150,7 @@ class Toolbar extends Component {
 
   render() {
     const style = [
-      ToolbarStyle.base,
-      this.state.position,
-      !this.state.show && {display: "none"}
+      ToolbarStyle.base
     ];
 
     const listStyle = [
@@ -160,19 +158,27 @@ class Toolbar extends Component {
       this.state.editingLink && {display: "none"}
     ];
 
+    const wrapperStyle = [
+      ToolbarStyle.wrapper,
+      !this.state.show && {display: "none"},
+      this.state.position
+    ];
+
     return (
-      <div style={style} ref="toolbar">
-        <ul style={listStyle} onMouseDown={(x) => {x.preventDefault();}}>
-          {this.props.actions.map(::this.renderButton)}
-        </ul>
-        <LinkInput
-          ref="textInput"
-          editorState={this.props.editorState}
-          onChange={this.props.onChange}
-          editingLink={this.state.editingLink}
-          editor={this.props.editor}
-          cancelLink={::this.cancelLink}/>
-        <span style={ToolbarStyle.arrow} />
+      <div style={wrapperStyle} ref="toolbarWrapper">
+        <div style={style} ref="toolbar">
+          <ul style={listStyle} onMouseDown={(x) => {x.preventDefault();}}>
+            {this.props.actions.map(::this.renderButton)}
+          </ul>
+          <LinkInput
+            ref="textInput"
+            editorState={this.props.editorState}
+            onChange={this.props.onChange}
+            editingLink={this.state.editingLink}
+            editor={this.props.editor}
+            cancelLink={::this.cancelLink}/>
+          <span style={ToolbarStyle.arrow} />
+        </div>
       </div>
     );
   }

--- a/src/styles/ToolbarStyles.js
+++ b/src/styles/ToolbarStyles.js
@@ -5,12 +5,18 @@
  */
 
 export default {
+  wrapper: {
+    background: "yellow",
+    height: 0,
+    position: "absolute"
+  },
+
   base: {
     backgroundColor: "#181818",
     borderRadius: "4px",
     boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.4)",
-    position: "absolute",
-    whiteSpace: "nowrap"
+    left: "-50%",
+    position: "relative"
   },
 
   arrow: {
@@ -29,6 +35,7 @@ export default {
 
   list: {
     padding: "0 8px",
-    margin: 0
+    margin: 0,
+    whiteSpace: "nowrap"
   }
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,12 +52,10 @@ export function getSelectionCoords(editor, toolbar) {
 
   const rangeWidth = rangeBounds.right - rangeBounds.left;
 
-  const toolbarWidth = toolbar.offsetWidth;
   const toolbarHeight = toolbar.offsetHeight;
   // const rangeHeight = rangeBounds.bottom - rangeBounds.top;
   const offsetLeft = (rangeBounds.left - editorBounds.left)
-            + (rangeWidth / 2)
-            - (toolbarWidth / 2);
+            + (rangeWidth / 2);
   const offsetTop = rangeBounds.top - editorBounds.top - (toolbarHeight + 14);
   return { offsetLeft, offsetTop };
 }

--- a/tests/toolbar_test.js
+++ b/tests/toolbar_test.js
@@ -140,7 +140,7 @@ describe("Toolbar Component", function() {
     });
 
     it("starts hidden", function() {
-      const toolbarNode = this.wrapper.refs.toolbar.refs.toolbar;
+      const toolbarNode = this.wrapper.refs.toolbar.refs.toolbarWrapper;
       expect(toolbarNode.style.display).to.be.equal("none");
     });
 
@@ -150,7 +150,7 @@ describe("Toolbar Component", function() {
         anchorOffset: 5
       }, this.wrapper);
 
-      const toolbarNode = this.wrapper.refs.toolbar.refs.toolbar;
+      const toolbarNode = this.wrapper.refs.toolbar.refs.toolbarWrapper;
       expect(toolbarNode.style.display).to.be.equal("");
     });
 
@@ -165,14 +165,14 @@ describe("Toolbar Component", function() {
         anchorOffset: 0
       }, this.wrapper);
 
-      const toolbarNode = this.wrapper.refs.toolbar.refs.toolbar;
+      const toolbarNode = this.wrapper.refs.toolbar.refs.toolbarWrapper;
       expect(toolbarNode.style.display).to.be.equal("none");
     });
 
     it("should center toolbar above the selection", function() {
       replaceSelection({focusOffset: 0, anchorOffset: 5}, this.wrapper);
 
-      const toolbarNode = this.wrapper.refs.toolbar.refs.toolbar;
+      const toolbarNode = this.wrapper.refs.toolbar.refs.toolbarWrapper;
 
       expect(toolbarNode.style.top).to.be.equal("-14px");
       expect(toolbarNode.style.left).to.be.equal("0.5px");


### PR DESCRIPTION
Now the toolbar is center aligned via CSS independently of its contents width.

Fixes #20