### PR TITLE
Link draftjs.org

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,7 +1,7 @@
 # Overview
 
 Megadraft is a Rich Text Editor built on top of Facebook's
-[draft.js](www.draftjs.org) framework
+[draft.js](https://facebook.github.io/draft-js/) framework
 
 ## How to use
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,7 +1,7 @@
 # Overview
 
 Megadraft is a Rich Text Editor built on top of Facebook's
-[draft.js](draftjs.org) framework
+[draft.js](www.draftjs.org) framework
 
 ## How to use
 


### PR DESCRIPTION
I changed the link draftjs.org because he was going to page 404 of the github