### PR TITLE
Remove babel-preset-stage-1 once stage-0 covers it

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["react", "es2015", "stage-1", "stage-0"],
+  "presets": ["react", "es2015", "stage-0"],
   "plugins": [
     "transform-decorators-legacy"
   ]

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-preset-stage-1": "^6.5.0",
     "chai": "^3.5.0",
     "es6-shim": "^0.35.0",
     "eslint": "^2.4.0",


### PR DESCRIPTION
According to babeljs website. The stage-0 package already includes stage-1 stage-2 and stage-3 https://babeljs.io/docs/plugins/preset-stage-0/