### PR TITLE
Import YuzuJS/setimmediate for setImmediate / clearImmediate browser compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-markdown": "^2.2.0",
     "react-tap-event-plugin": "^1.0.0",
     "rimraf": "^2.5.2",
+    "setimmediate": "^1.0.4",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
     "svgo": "^0.6.6",

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -8,7 +8,7 @@ import React, {Component} from "react";
 import ReactDOM from "react-dom";
 import icons from "../icons";
 
-import 'setimmediate';
+import "setimmediate";
 
 
 class BlockStyles extends Component {

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -8,6 +8,8 @@ import React, {Component} from "react";
 import ReactDOM from "react-dom";
 import icons from "../icons";
 
+import 'setimmediate';
+
 
 class BlockStyles extends Component {
   render() {


### PR DESCRIPTION
When using browserify for client-side rendering, functions setImmediate and clearImmediate cannot be executed in the browser. This is why I propose to integrate the external library YuzuJS/setImmediate, which allows to execute these functions also in the browser.