### PR TITLE
Allow to customize the toolbar

### DIFF
--- a/src/Megadraft.js
+++ b/src/Megadraft.js
@@ -13,7 +13,7 @@ import Toolbar from "./components/Toolbar";
 import Sidebar from "./components/Sidebar";
 import Media from "./components/Media";
 import DEFAULT_PLUGINS from "./plugins/default";
-
+import DEFAULT_ACTIONS from "./actions/default";
 
 export default class Megadraft extends Component {
   constructor(props) {
@@ -25,17 +25,7 @@ export default class Megadraft extends Component {
 
     this.setReadOnly = ::this.setReadOnly;
 
-    this.actions = [
-      {type: "inline", label: "B", style: "BOLD", icon: icons.BoldIcon},
-      {type: "inline", label: "I", style: "ITALIC", icon: icons.ItalicIcon},
-      {type: "entity", label: "Link", style: "link", icon: icons.LinkIcon},
-      {type: "separator"},
-      {type: "block", label: "UL", style: "unordered-list-item", icon: icons.ULIcon},
-      {type: "block", label: "OL", style: "ordered-list-item", icon: icons.OLIcon},
-      {type: "block", label: "H2", style: "header-two", icon: icons.H2Icon},
-      {type: "block", label: "QT", style: "blockquote", icon: icons.BlockQuoteIcon}
-    ];
-
+    this.actions = this.props.actions || DEFAULT_ACTIONS;
     this.plugins = this.props.plugins || DEFAULT_PLUGINS;
   }
 

--- a/src/actions/default.js
+++ b/src/actions/default.js
@@ -1,0 +1,12 @@
+import icons from "../icons";
+
+export default [
+  {type: "inline", label: "B", style: "BOLD", icon: icons.BoldIcon},
+  {type: "inline", label: "I", style: "ITALIC", icon: icons.ItalicIcon},
+  {type: "entity", label: "Link", style: "link", icon: icons.LinkIcon},
+  {type: "separator"},
+  {type: "block", label: "UL", style: "unordered-list-item", icon: icons.ULIcon},
+  {type: "block", label: "OL", style: "ordered-list-item", icon: icons.OLIcon},
+  {type: "block", label: "H2", style: "header-two", icon: icons.H2Icon},
+  {type: "block", label: "QT", style: "blockquote", icon: icons.BlockQuoteIcon}
+];


### PR DESCRIPTION
I think the toolbar should be customizable. I propose this simple implementation, based on the plugins customization.

Example :

```
import Megadraft, { MegadraftIcons } from 'megadraft';

...

const actions = [
  {type: "inline", label: "B", style: "BOLD", icon: MegadraftIcons.BoldIcon},
  {type: "inline", label: "I", style: "ITALIC", icon: MegadraftIcons.ItalicIcon}
];

...

class CustomTextEditor extends React.Component {

...

render() {
    return (
      <Megadraft
        editorState={this.state.value}
        actions={actions}
        placeholder="Text"
        onChange={this.onChange}
      />
    );
  }
```