### PR TITLE
Add custom key bindings

### DIFF
--- a/website/components/example.js
+++ b/website/components/example.js
@@ -30,7 +30,6 @@ const muiTheme = getMuiTheme({
   }
 });
 
-
 class Example extends React.Component {
 
   getChildContext() {
@@ -48,6 +47,9 @@ class Example extends React.Component {
   constructor(props) {
     super(props);
     const content = editorStateFromRaw(INITIAL_CONTENT);
+    this.keyBindings = [
+        { name: "save", isKeyBound: (e) => { return e.keyCode === 83 && e.ctrlKey; }, action: () => { this.onSave(); } }
+    ];
     this.state = {
       value: content,
       activeTab: "a"
@@ -66,6 +68,10 @@ class Example extends React.Component {
     });
   }
 
+  onSave() {
+    console.log("save");
+  }
+
   render() {
     const icon_edit = <FontIcon className="material-icons">mode_edit</FontIcon>;
     const icon_code = <FontIcon className="material-icons">code</FontIcon>;
@@ -77,7 +83,8 @@ class Example extends React.Component {
             <Megadraft
               editorState={this.state.value}
               placeholder="Text"
-              onChange={::this.onChange} />
+              onChange={::this.onChange}
+              keyBindings={this.keyBindings}/>
           </div>
         </Tab>
         <Tab label="Content JSON" value="b" icon={icon_code}>


### PR DESCRIPTION
Hi,

I need to add external key bindings to my editor, to save the text for example. I think it's a common need. I made this, I hope you'll find it interesting.

Everything is handled in the Megadraft component. The key bindings must be passed to the component as parameter, like this :

```
const keyBindings = [
        { name: "save", isKeyBound: (e) => { return e.keyCode === 83 && e.ctrlKey; }, action: () => { this.onSave(); } }
    ];
<Megadraft
              keyBindings={keyBindings}/>
```

First parameter is the name of the key binding ; second the test for checking if the key is bound or not ; third the action to execute when the key is bound.

As you can see, the test for checking if the key is bound or not is done outside the component, to avoid to import Draft-JS namespaces.

Then, in the megadraft component, a function overrides the default function "getDefaultKeyBinding" : 
```
externalKeyBindings(e): string {
    for (const kb of this.keyBindings) {
      if (kb.isKeyBound(e)) {
        return kb.name;
      }
    }
    return getDefaultKeyBinding(e);
  }

...

<Editor 
    keyBindingFn={this.externalKeyBindings}
/>
```

The existing handleKeyCommand function is edited as well : 
```
handleKeyCommand(command) {
    // external key bindings
    var extKb = this.keyBindings.find(kb => kb.name === command);
    if(extKb) {
      extKb.action();
      return true;
    }
   ...
}
```

Of course, if the parameter keyBindings is not passed to Megadraft, nothing changes.

I've added two tests to check externalKeyBindings and handleKeyCommand, and edited website/example.js for a complete example.