### PR TITLE
Insert media block helper

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -64,6 +64,7 @@ a DraftJS' entity:
 ```js
 import React, {Component} from "react";
 import {DraftJS} from "megadraft";
+import {insertMediaBlock} from "megadraft/lib/utils"
 
 export default class BlockButton extends Component {
   constructor(props) {
@@ -73,14 +74,8 @@ export default class BlockButton extends Component {
   onClick(e) {
     e.preventDefault();
     const src = window.prompt("Enter a URL");
-    // Creates a new entity
-    const entityKey = DraftJS.Entity.create("image", "IMMUTABLE", {src});
     // Calls the onChange method with the new state.
-    this.props.onChange(DraftJS.AtomicBlockUtils.insertAtomicBlock(
-      this.props.editorState,
-      entityKey,
-      "*"
-    ));
+    this.props.onChange(insertMediaBlock(this.props.editorState, "image", {src}));
   }
 
   render() {
@@ -104,9 +99,7 @@ example:
 ```js
 import React, {Component} from "react";
 
-
 export default class ImageBlock extends Component {
-
   render(){
     return (
       <img src={this.props.data.src} />

--- a/src/plugins/image/ImageButton.js
+++ b/src/plugins/image/ImageButton.js
@@ -5,9 +5,9 @@
  */
 
 import React, {Component} from "react";
-import {Entity, AtomicBlockUtils} from "draft-js";
 
 import icons from "../../icons";
+import {insertMediaBlock} from "../../utils";
 
 
 export default class BlockButton extends Component {
@@ -23,13 +23,7 @@ export default class BlockButton extends Component {
       return;
     }
 
-    const entityKey = Entity.create("image", "IMMUTABLE", {src});
-
-    this.props.onChange(AtomicBlockUtils.insertAtomicBlock(
-      this.props.editorState,
-      entityKey,
-      "🍺"
-    ));
+    this.props.onChange(insertMediaBlock(this.props.editorState, "image", {src}));
   }
 
   render() {

--- a/src/plugins/video/VideoButton.js
+++ b/src/plugins/video/VideoButton.js
@@ -5,9 +5,9 @@
  */
 
 import React, {Component} from "react";
-import {Entity, AtomicBlockUtils} from "draft-js";
 
 import icons from "../../icons";
+import {insertMediaBlock} from "../../utils";
 
 
 export default class VideoButton extends Component {
@@ -24,13 +24,7 @@ export default class VideoButton extends Component {
       return;
     }
 
-    const entityKey = Entity.create("video", "IMMUTABLE", {src});
-
-    this.props.onChange(AtomicBlockUtils.insertAtomicBlock(
-      this.props.editorState,
-      entityKey,
-      "🍺"
-    ));
+    this.props.onChange(insertMediaBlock(this.props.editorState, "video", {src}));
   }
 
   render() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,9 @@ import {
   convertToRaw,
   convertFromRaw,
   EditorState,
-  getVisibleSelectionRect} from "draft-js";
+  getVisibleSelectionRect,
+  Entity,
+  AtomicBlockUtils} from "draft-js";
 
 import decorator from "./decorator";
 
@@ -60,4 +62,14 @@ export function getSelectionCoords(editor, toolbar) {
             + (rangeWidth / 2);
   const offsetTop = rangeBounds.top - editorBounds.top - (toolbarHeight + 14);
   return { offsetLeft, offsetTop };
+}
+
+export function insertMediaBlock (editorState, blockType, data) {
+  const entityKey = Entity.create(blockType, "IMMUTABLE", data);
+
+  return AtomicBlockUtils.insertAtomicBlock(
+    editorState,
+    entityKey,
+    "🍺"
+  );
 }

--- a/tests/utils/insertMediaBlock_test.js
+++ b/tests/utils/insertMediaBlock_test.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016, Globo.com (https://github.com/globocom)
+ *
+ * License: MIT
+ */
+
+import {Entity} from "draft-js";
+import chai from "chai";
+
+import {insertMediaBlock, editorStateFromRaw} from "../../src/utils";
+
+let expect = chai.expect;
+
+
+describe("insertMediaBlock", function() {
+  beforeEach(function () {
+    this.state = editorStateFromRaw(null);
+    this.data = {
+      url: "media.jpg"
+    };
+
+    this.blockType = "plugin-media-type";
+    this.newState = insertMediaBlock(this.state, this.blockType, this.data);
+    this.block = this.newState.getCurrentContent().getBlockMap().find(block => block.type === "atomic");
+  });
+
+  it("returns state with new block", function () {
+    expect(this.block).to.be.truthy;
+    expect(this.block.text).to.equal("🍺");
+  });
+
+  it("applies entity to block", function () {
+    const entityKey = this.block.getEntityAt(0);
+    const entity = Entity.get(entityKey);
+
+    expect(entity.type).to.equal(this.blockType);
+    expect(entity.getData()).to.equal(this.data);
+  });
+});


### PR DESCRIPTION
This includes a `insertMediaBlock` helper to make writing plugins easier.

It will also help with #55, so plugin authors won't have to change their block creation code.