### PR TITLE
fix empty editorState sidebar jump

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -151,7 +151,7 @@ export default class SideBar extends Component {
       (container.getBoundingClientRect().top -
         document.documentElement.clientTop));
 
-    if (this.state.top !== top) {
+    if (this.state.top !== top && top > 0) {
       this.setState({
         top: top
       });


### PR DESCRIPTION
As soon as you click on an empty page, the calculation for the top margin for the sidemenu is done, but it comes out as -4, as there are no elements to count. This means the sidebar jumps, but not allowing the top margin to go below 0 fixes this.