### PR TITLE
allow to pass blockRenderMap

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -169,6 +169,7 @@ export default class MegadraftEditor extends Component {
           <Editor
             readOnly={this.state.readOnly}
             plugins={plugins}
+            blockRenderMap={this.props.blockRenderMap}
             blockRendererFn={this.mediaBlockRenderer}
             blockStyleFn={this.blockStyleFn}
             onTab={this.onTab}


### PR DESCRIPTION
This allows to change the blockRenderMap, which might be helpful if you want to render custom components.