### PR TITLE
hide sidebar and toolbar when readOnly

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -162,10 +162,13 @@ export default class MegadraftEditor extends Component {
           className="megadraft-editor"
           id="megadraft-editor"
           ref="editor">
-          <Sidebar
-            plugins={plugins}
-            editorState={editorState}
-            onChange={this.onChange}/>
+          { !this.state.readOnly ?
+            <Sidebar
+              plugins={plugins}
+              editorState={editorState}
+              onChange={this.onChange} /> :
+            null
+          }
           <Editor
             readOnly={this.state.readOnly}
             plugins={plugins}
@@ -180,11 +183,14 @@ export default class MegadraftEditor extends Component {
             editorState={editorState}
             placeholder={this.props.placeholder}
             onChange={this.onChange} />
-          <Toolbar
-            editor={this.refs.editor}
-            editorState={editorState}
-            onChange={this.onChange}
-            actions={this.actions}/>
+          { !this.state.readOnly ?
+            <Toolbar
+              editor={this.refs.editor}
+              editorState={editorState}
+              onChange={this.onChange}
+              actions={this.actions}/> :
+              null
+          }
         </div>
       </div>
     );

--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -162,13 +162,11 @@ export default class MegadraftEditor extends Component {
           className="megadraft-editor"
           id="megadraft-editor"
           ref="editor">
-          { !this.state.readOnly ?
-            <Sidebar
-              plugins={plugins}
-              editorState={editorState}
-              onChange={this.onChange} /> :
-            null
-          }
+          <Sidebar
+            plugins={plugins}
+            editorState={editorState}
+            readOnly={this.state.readOnly}
+            onChange={this.onChange} />
           <Editor
             readOnly={this.state.readOnly}
             plugins={plugins}
@@ -183,14 +181,12 @@ export default class MegadraftEditor extends Component {
             editorState={editorState}
             placeholder={this.props.placeholder}
             onChange={this.onChange} />
-          { !this.state.readOnly ?
-            <Toolbar
-              editor={this.refs.editor}
-              editorState={editorState}
-              onChange={this.onChange}
-              actions={this.actions}/> :
-              null
-          }
+          <Toolbar
+            editor={this.refs.editor}
+            editorState={editorState}
+            readOnly={this.state.readOnly}
+            onChange={this.onChange}
+            actions={this.actions}/>
         </div>
       </div>
     );

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -153,7 +153,7 @@ export default class SideBar extends Component {
 
     const element = getSelectedBlockElement();
 
-    if (!element) {
+    if (!element || !container) {
       return;
     }
 
@@ -169,6 +169,9 @@ export default class SideBar extends Component {
   }
 
   render() {
+    if(this.props.readOnly) {
+      return null;
+    }
     return (
       <div ref="container" className="sidebar">
         <div style={{top: `${this.state.top}px`}} className="sidebar__menu">

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -152,11 +152,13 @@ export default class Toolbar extends Component {
   }
 
   render() {
+    if(this.props.readOnly) {
+      return null;
+    }
     const toolbarClass = classNames("toolbar", {
       "toolbar--open": this.state.show,
       "toolbar--editing-link": this.state.editingLink
     });
-
     return (
       <div className={toolbarClass}
            style={this.state.position}

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -159,6 +159,7 @@ export default class Toolbar extends Component {
       "toolbar--open": this.state.show,
       "toolbar--editing-link": this.state.editingLink
     });
+    
     return (
       <div className={toolbarClass}
            style={this.state.position}

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,7 +48,7 @@ export function getSelectionCoords(editor, toolbar) {
   const editorBounds = editor.getBoundingClientRect();
   const rangeBounds = getVisibleSelectionRect(window);
 
-  if (!rangeBounds) {
+  if (!rangeBounds || !toolbar) {
     return null;
   }
 

--- a/tests/components/sidebar_test.js
+++ b/tests/components/sidebar_test.js
@@ -37,6 +37,7 @@ class SidebarWrapper extends Component {
           ref="sidebar"
           plugins={this.plugins}
           editorState={this.state.editorState}
+          readOnly={this.props.readOnly}
           onChange={this.onChange} />
       </div>
     );
@@ -69,6 +70,14 @@ describe("Sidebar Component", function() {
   it("renders correctly on the page", function() {
     const sidebar = this.wrapper.find(Sidebar);
     expect(sidebar).to.have.length(1);
+    expect(sidebar.html()).not.to.be.null;
+  });
+  it("renders as null when readOnly is set", function() {
+    const wrapper = mount(
+      <SidebarWrapper readOnly editorState={this.editorState}/>
+    );
+    const sidebar = wrapper.find(Sidebar);
+    expect(sidebar.html()).to.be.null;
   });
 
   it("renders enabled plugins", function() {

--- a/tests/components/sidebar_test.js
+++ b/tests/components/sidebar_test.js
@@ -72,6 +72,7 @@ describe("Sidebar Component", function() {
     expect(sidebar).to.have.length(1);
     expect(sidebar.html()).not.to.be.null;
   });
+  
   it("renders as null when readOnly is set", function() {
     const wrapper = mount(
       <SidebarWrapper readOnly editorState={this.editorState}/>

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -37,6 +37,7 @@ export default class ToolbarWrapper extends Component {
           editor={this.refs.editor}
           editorState={this.state.editorState}
           actions={this.props.actions}
+          readOnly={this.props.readOnly}
           onChange={this.onChange} />
       </div>
     );
@@ -104,6 +105,13 @@ describe("Toolbar Component", function() {
     it("renders separator", function() {
       const items = this.wrapper.find(Separator);
       expect(items).to.have.length(1);
+    });
+    it("renders as null when readOnly is set", function() {
+      const wrapper = mount(
+        <ToolbarWrapper readOnly editorState={this.editorState} actions={this.actions} />
+      );
+      const toolbar = wrapper.find(Toolbar);
+      expect(toolbar.html()).to.be.null;
     });
 
     describe("actions", function () {

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -106,6 +106,7 @@ describe("Toolbar Component", function() {
       const items = this.wrapper.find(Separator);
       expect(items).to.have.length(1);
     });
+    
     it("renders as null when readOnly is set", function() {
       const wrapper = mount(
         <ToolbarWrapper readOnly editorState={this.editorState} actions={this.actions} />


### PR DESCRIPTION
This hides the sidebar (with the plugins) and the toolbar when readyOnly prop is true