### PR TITLE
Document custom toolbar and keybindings

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -100,7 +100,124 @@ source on your build, if you wish.
 <link href="node_modules/megadraft/dist/css/megadraft.css" rel="stylesheet">
 ```
 
+### Custom Toolbar
 
+You can provide custom actions using MegadraftEditor `actions` property. Megadraft Toolbar provides [custom actions](https://github.com/globocom/megadraft/blob/master/src/actions/default.js) like **Bold** and *Italic*, additionaly you can provide your own custom actions or even add some custom actions to the default ones.
+
+Example: Add an underlined action
+
+```js
+import React from "react";
+import ReactDOM from "react-dom";
+import {MegadraftEditor, editorStateFromRaw} from "megadraft";
+import CustomSidebar from 'my/sidebar/path';
+
+import actions from "megadraft/actions/default";
+
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {editorState: editorStateFromRaw(null)};
+    this.onChange = ::this.onChange;
+  }
+
+  onChange(editorState) {
+    this.setState({editorState});
+  }
+  render() {
+    const custom_actions = actions.concat([{type: "inline", label: "U", style: "UNDERLINE", icon: Underlined}]);
+    return (
+      <MegadraftEditor
+        editorState={this.state.editorState}
+        onChange={this.onChange}
+        actions={custom_actions}/>
+    )
+  }
+}
+
+/**
+ * Underlined Icon.
+ * svg extracted from [Material UI underlined icon](https://material.io/icons/#ic_format_underlined)
+ */
+class Underlined extends React.Component {
+  render() {
+    return (
+      <svg {...this.props} height="24" viewBox="0 0 24 24" width="24">
+        <path d="M0 0h24v24H0z" fill="none" />
+        <path fill="currentColor" fillRule="evenodd" d="M12 17c3.31 0 6-2.69 6-6V3h-2.5v8c0 1.93-1.57 3.5-3.5 3.5S8.5 12.93 8.5 11V3H6v8c0 3.31 2.69 6 6 6zm-7 2v2h14v-2H5z" />
+      </svg>
+    );
+  }
+}
+
+ReactDOM.render(
+  <App />,
+  document.getElementById('container')
+);
+
+```
+
+## Custom Keybindings
+
+You can provide custom key bindings to Megadraft by setting the `keyBindingFn` property.
+
+Example: Call a function when user presses control s
+
+```js
+import React from "react";
+import ReactDOM from "react-dom";
+import {MegadraftEditor, editorStateFromRaw} from "megadraft";
+import CustomSidebar from 'my/sidebar/path';
+
+import actions from "megadraft/actions/default";
+
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {editorState: editorStateFromRaw(null)};
+    this.onChange = ::this.onChange;
+    this.keyBindings = [
+        { name: "save", isKeyBound: (e) => { return e.keyCode === 83 && e.ctrlKey; }, action: () => { this.onSave(); } }
+    ];
+  }
+
+  onChange(editorState) {
+    this.setState({editorState});
+  }
+  onSave() {
+    console.log("save");
+  }
+  render() {
+    return (
+      <MegadraftEditor
+        editorState={this.state.editorState}
+        onChange={this.onChange}
+        keyBindings={this.keyBindings}/>
+    )
+  }
+}
+
+/**
+ * Underlined Icon.
+ * svg extracted from [Material UI underlined icon](https://material.io/icons/#ic_format_underlined)
+ */
+class Underlined extends React.Component {
+  render() {
+    return (
+      <svg {...this.props} height="24" viewBox="0 0 24 24" width="24">
+        <path d="M0 0h24v24H0z" fill="none" />
+        <path fill="currentColor" fillRule="evenodd" d="M12 17c3.31 0 6-2.69 6-6V3h-2.5v8c0 1.93-1.57 3.5-3.5 3.5S8.5 12.93 8.5 11V3H6v8c0 3.31 2.69 6 6 6zm-7 2v2h14v-2H5z" />
+      </svg>
+    );
+  }
+}
+
+ReactDOM.render(
+  <App />,
+  document.getElementById('container')
+);
+
+```
 ## Editor props
 
 - `placeholder` Editor's placeholder text
@@ -109,3 +226,5 @@ source on your build, if you wish.
 - `onChange` Function fired on editor state changes
 - `sidebarRendererFn` (optional) it is called to render a custom sidebar. This method must
 return a valid React element.
+- `actions` (optional) List of actions to render in Toolbar
+- `keyBindings` (optional) Custom key bindings


### PR DESCRIPTION
Added a couple of examples of adding custom actions to toolbar and custom key bindings. This is in response to issue #62 
