### PR TITLE
Feature/custom toolbar

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -169,6 +169,7 @@ export default class MegadraftEditor extends Component {
           <Editor
             readOnly={this.state.readOnly}
             plugins={plugins}
+            blockRenderMap={this.props.blockRenderMap}
             blockRendererFn={this.mediaBlockRenderer}
             blockStyleFn={this.blockStyleFn}
             onTab={this.onTab}

--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -7,7 +7,7 @@
 import React, {Component} from "react";
 import {Editor, RichUtils, getDefaultKeyBinding} from "draft-js";
 
-import Toolbar from "./Toolbar";
+import DefaultToolbar from "./Toolbar";
 import Sidebar from "./Sidebar";
 import Media from "./Media";
 import DEFAULT_PLUGINS from "../plugins/default";
@@ -162,10 +162,7 @@ export default class MegadraftEditor extends Component {
   }
 
   renderToolbar(props) {
-    const { toolbarRendererFn } = this.props;
-    if(typeof toolbarRendererFn === "function") {
-      return toolbarRendererFn(props);
-    }
+    const { Toolbar = DefaultToolbar } = this.props;
     return <Toolbar {...props} />;
   }
 

--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -161,6 +161,14 @@ export default class MegadraftEditor extends Component {
     return <Sidebar {...props} />;
   }
 
+  renderToolbar(props) {
+    const { toolbarRendererFn } = this.props;
+    if(typeof toolbarRendererFn === "function") {
+      return toolbarRendererFn(props);
+    }
+    return <Toolbar {...props} />;
+  }
+
   render() {
     const {editorState, stripPastedStyles, spellCheck} = this.props;
     const plugins = this.plugins;
@@ -192,12 +200,13 @@ export default class MegadraftEditor extends Component {
             editorState={editorState}
             placeholder={this.props.placeholder}
             onChange={this.onChange} />
-          <Toolbar
-            editor={this.refs.editor}
-            editorState={editorState}
-            readOnly={this.state.readOnly}
-            onChange={this.onChange}
-            actions={this.actions}/>
+          {this.renderToolbar({
+            editor: this.refs.editor,
+            editorState,
+            readOnly: this.state.readOnly,
+            onChange: this.onChange,
+            actions: this.actions
+          })}
         </div>
       </div>
     );

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -13,6 +13,7 @@ import {mount} from "enzyme";
 import MegadraftEditor from "../../src/components/MegadraftEditor";
 import Media from "../../src/components/Media";
 import Sidebar from "../../src/components/Sidebar";
+import Toolbar from "../../src/components/Toolbar";
 import {editorStateFromRaw} from "../../src/utils";
 import image from "../../src/plugins/image/plugin";
 
@@ -259,4 +260,65 @@ describe("MegadraftEditor Component", () => {
     const sidebar = wrapper.find(MyCustomSidebar);
     expect(sidebar).to.have.length(1);
   });
+
+  it("renders default toolbar if toolbarRendererFn not provided", function() {
+    const toolbar = this.wrapper.find(Toolbar);
+    expect(toolbar).to.have.length(1);
+  });
+
+  it("passes required props to default toolbar", function() {
+    const toolbar = this.wrapper.find(Toolbar);
+    // editor is undefined :-/
+    //expect(toolbar.prop("editor")).to.equal(this.component.refs.editor);
+    expect(toolbar.prop("actions")).to.equal(this.component.actions);
+    expect(toolbar.prop("onChange")).to.equal(this.component.onChange);
+    expect(toolbar.prop("editorState")).to.equal(this.editorState);
+    expect(toolbar.prop("readOnly")).to.equal(false);
+  });
+
+  it("calls toolbarRendererFn if it's provided", function() {
+    const renderCustomToolbar = sinon.spy();
+    const wrapper = mount(
+      <MegadraftEditor
+        editorState={this.editorState}
+        onChange={this.onChange}
+        toolbarRendererFn={renderCustomToolbar} />
+    );
+
+    const component = wrapper.get(0);
+    const expectedProps = {
+      //editor: this.component.refs.editor,
+      editor: undefined, // editor is undefined :-/
+      actions: component.actions,
+      onChange: component.onChange,
+      editorState: this.editorState,
+      readOnly: false
+    };
+    expect(renderCustomToolbar.calledWith(expectedProps)).to.be.true;
+  });
+
+  it("renders custom toolbar if toolbarRendererFn is provided", function() {
+    class MyCustomToolbar extends React.Component {
+      render() {
+        return (
+          <div>
+            <span>My custom Toolbar</span>
+          </div>
+        );
+      }
+    }
+    const renderCustomToolbar = function(props) {
+      return <MyCustomToolbar {...props}/>;
+    };
+    const wrapper = mount(
+      <MegadraftEditor
+        editorState={this.editorState}
+        onChange={this.onChange}
+        toolbarRendererFn={renderCustomToolbar} />
+    );
+    const toolbar = wrapper.find(MyCustomToolbar);
+    expect(toolbar).to.have.length(1);
+  });
+
+
 });

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -261,7 +261,7 @@ describe("MegadraftEditor Component", () => {
     expect(sidebar).to.have.length(1);
   });
 
-  it("renders default toolbar if toolbarRendererFn not provided", function() {
+  it("renders default toolbar if Tooolbar not provided", function() {
     const toolbar = this.wrapper.find(Toolbar);
     expect(toolbar).to.have.length(1);
   });
@@ -276,28 +276,8 @@ describe("MegadraftEditor Component", () => {
     expect(toolbar.prop("readOnly")).to.equal(false);
   });
 
-  it("calls toolbarRendererFn if it's provided", function() {
-    const renderCustomToolbar = sinon.spy();
-    const wrapper = mount(
-      <MegadraftEditor
-        editorState={this.editorState}
-        onChange={this.onChange}
-        toolbarRendererFn={renderCustomToolbar} />
-    );
 
-    const component = wrapper.get(0);
-    const expectedProps = {
-      //editor: this.component.refs.editor,
-      editor: undefined, // editor is undefined :-/
-      actions: component.actions,
-      onChange: component.onChange,
-      editorState: this.editorState,
-      readOnly: false
-    };
-    expect(renderCustomToolbar.calledWith(expectedProps)).to.be.true;
-  });
-
-  it("renders custom toolbar if toolbarRendererFn is provided", function() {
+  it("renders custom toolbar if Toolbar is provided", function() {
     class MyCustomToolbar extends React.Component {
       render() {
         return (
@@ -307,17 +287,18 @@ describe("MegadraftEditor Component", () => {
         );
       }
     }
-    const renderCustomToolbar = function(props) {
-      return <MyCustomToolbar {...props}/>;
-    };
+
     const wrapper = mount(
       <MegadraftEditor
         editorState={this.editorState}
-        onChange={this.onChange}
-        toolbarRendererFn={renderCustomToolbar} />
+        onChange={this.component.onChange}
+        Toolbar={MyCustomToolbar} />
     );
     const toolbar = wrapper.find(MyCustomToolbar);
     expect(toolbar).to.have.length(1);
+    expect(toolbar.prop("actions")).to.equal(this.component.actions);
+    expect(toolbar.prop("editorState")).to.equal(this.editorState);
+    expect(toolbar.prop("readOnly")).to.equal(false);
   });
 
 


### PR DESCRIPTION
This allows to specify a custom toolbar. I took the style of the custom-sidebar-option.

two remarks:

- one test has a problem which i could not fix yet. Toolbar receives this.component.refs.editor, but this is undefined in the test and i don't know why.
- the names props.toolbarRendererFn as well as props.sidebarRendererFn are not really idiomatic, because a function that returns a react-element is a Component. They therefore should be named props.Toolbar and props.Sidebar (my opinion)

anyway, it works and could be merged.
