### PR TITLE
Toolbar now allows to update entities (links, etc.).

### DIFF
--- a/docs/custom_entities.md
+++ b/docs/custom_entities.md
@@ -81,6 +81,7 @@ Every entity input component will receive the following properties:
 - `entityType`: the entity type (string) like `LINK` or `INTERNAL_PAGE_LINK`
 - `setEntity`: call this function to set the entity on the current selection.
 You can pass an object that gets assigned as the data of the entity. (see example below)
+- `removeEntity`: call this to remove the entity. It will also call `cancelEntity` afterwards.
 - `cancelEntity`: call this if you want to close the entity input and show the normal toolbar.
 - `editorState`: the current draftjs `editorState`.
 - `onChange`: call this if you want to manually change the `editorState`.

--- a/src/entity_inputs/LinkInput.js
+++ b/src/entity_inputs/LinkInput.js
@@ -65,13 +65,14 @@ export default class LinkInput extends Component {
           value={this.state.url}
           onKeyDown={this.onLinkKeyDown}
           placeholder="Type the url and press enter"/>
-        <button
-          onClick={this.props.removeEntity}
-          type="button"
-          style={{verticalAlign: "bottom"}}
-          className="toolbar__button toolbar__item">
-          <DeleteIcon />
-        </button>
+        <span className="toolbar__item" style={{verticalAlign: "bottom"}}>
+          <button
+            onClick={this.props.removeEntity}
+            type="button"
+            className="toolbar__button">
+            <DeleteIcon />
+          </button>
+        </span>
 
       </div>
     );

--- a/src/entity_inputs/LinkInput.js
+++ b/src/entity_inputs/LinkInput.js
@@ -5,29 +5,29 @@
  */
 
 import React, {Component} from "react";
-
+import DeleteIcon from "../icons/delete";
 
 export default class LinkInput extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      link: ""
+      url: props && props.url || ""
     };
     this.onLinkChange = ::this.onLinkChange;
     this.onLinkKeyDown = ::this.onLinkKeyDown;
   }
 
   setLink() {
-    let {link} = this.state;
-    if (!link.startsWith("http://") && !link.startsWith("https://")) {
-      link = `http://${link}`;
+    let {url} = this.state;
+    if (!url.startsWith("http://") && !url.startsWith("https://")) {
+      url = `http://${url}`;
     }
-    this.props.setEntity({url: link});
+    this.props.setEntity({url});
   }
 
   onLinkChange(event) {
     event.stopPropagation();
-    this.setState({link: event.target.value});
+    this.setState({url: event.target.value});
   }
 
   onLinkKeyDown(event) {
@@ -35,7 +35,7 @@ export default class LinkInput extends Component {
       event.preventDefault();
       this.setLink();
       this.setState({
-        link: ""
+        url: ""
       });
       this.props.cancelEntity();
 
@@ -43,7 +43,7 @@ export default class LinkInput extends Component {
     } else if (event.key == "Escape") {
       event.preventDefault();
       this.setState({
-        link: ""
+        url: ""
       });
       this.props.cancelEntity();
 
@@ -56,14 +56,24 @@ export default class LinkInput extends Component {
 
   render() {
     return (
-      <input
-        ref="textInput"
-        type="text"
-        className="toolbar__input"
-        onChange={this.onLinkChange}
-        value={this.state.link}
-        onKeyDown={this.onLinkKeyDown}
-        placeholder="Type the link and press enter"/>
+      <div style={{whiteSpace: "nowrap"}}>
+        <input
+          ref="textInput"
+          type="text"
+          className="toolbar__input"
+          onChange={this.onLinkChange}
+          value={this.state.url}
+          onKeyDown={this.onLinkKeyDown}
+          placeholder="Type the url and press enter"/>
+        <button
+          onClick={this.props.removeEntity}
+          type="button"
+          style={{verticalAlign: "bottom"}}
+          className="toolbar__button toolbar__item">
+          <DeleteIcon />
+        </button>
+
+      </div>
     );
   }
 }

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -244,7 +244,7 @@ describe("Toolbar Component", function() {
         expect(url).to.be.equal("http://www.globo.com");
       });
 
-      it("(integration) LinkInput should remove an entity when button clicked is again", function() {
+      it("(integration) LinkInput should remove an entity when ", function() {
         this.linkButton().simulate("click");
 
         const input = this.wrapper.find(LinkEntityInput).find("input");
@@ -253,9 +253,13 @@ describe("Toolbar Component", function() {
         inputNode.value = "http://www.globo.com";
         input.simulate("change");
         input.simulate("keyDown", {key: "Enter", keyCode: 13, which: 13});
+        // show dialog again
         this.linkButton().simulate("click");
-        const contentState = this.wrapper.state("editorState").getCurrentContent();
+        // click on remove
+        const removeButton = this.wrapper.find(LinkEntityInput).find("button");
+        removeButton.simulate("click");
 
+        const contentState = this.wrapper.state("editorState").getCurrentContent();
         const blockWithLinkAtBeginning = contentState.getBlockForKey("ag6qs");
         const linkKey = blockWithLinkAtBeginning.getEntityAt(0);
 
@@ -268,9 +272,15 @@ describe("Toolbar Component", function() {
         const input = this.wrapper.find(LinkEntityInput).find("input");
         const inputNode = input.get(0);
 
+
         inputNode.value = "www.globo.com";
         input.simulate("change");
         input.simulate("keyDown", {key: "Enter", keyCode: 13, which: 13});
+        // show dialog again
+        this.linkButton().simulate("click");
+        // click on remove
+        const removeButton = this.wrapper.find(LinkEntityInput).find("button");
+        removeButton.simulate("click");
 
         replaceSelection({
           anchorOffset: 5,


### PR DESCRIPTION
Fixes https://github.com/globocom/megadraft/issues/98

If you click on an action for an entity (e.g. LinkInput) and the entity is already active, it will no longer remove that entity and instead show the entity-action again.

Entity-inputs like LinkInput now receive a prop removeEntity, that can be called to remove the entity.

I added a remove-button to the default LinkInput that calls this action, so there is no regression.

Nevertheless, it is a small breaking-change if you had used the custom-entity feature, although it is quite easy to fix. Still i would suggest to bump the version to 0.5.0 ;-)

