### PR TITLE
Fix the lint command to apply to config files and fix the linter error on these files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,38 +4,38 @@
  * License: MIT
  */
 
-var gulp = require("gulp");
-var gutil = require("gulp-util");
-var sass = require("gulp-sass");
-var autoprefixer = require("gulp-autoprefixer");
-var webpack = require("webpack");
-var WebpackDevServer = require("webpack-dev-server");
-var webpackConfig = require("./webpack.config.js");
+const gulp = require("gulp");
+const gutil = require("gulp-util");
+const sass = require("gulp-sass");
+const autoprefixer = require("gulp-autoprefixer");
+const webpack = require("webpack");
+const WebpackDevServer = require("webpack-dev-server");
+const webpackConfig = require("./webpack.config.js");
 
 
 // The development server (the recommended option for development)
 gulp.task("default", ["dev-server"]);
 
-var host = "localhost";
-var port = 8080;
+const host = "localhost";
+const port = 8080;
 
 // http://stackoverflow.com/questions/30225866/gulp-webpack-dev-server-callback-before-bundle-is-finished
-var hook_stream = function( stream, data, cb ) {
+const hookStream = function( stream, data, cb ) {
   // Reference default write method
-  var old_write = stream.write;
+  const oldWrite = stream.write;
 
   // Clear hook function
-  var clear_hook = function() {
-    stream.write = old_write;
+  const clearHook = function() {
+    stream.write = oldWrite;
   };
 
   // New stream write with our shiny function
   stream.write = function() {
     // Old behaviour
-    old_write.apply( stream, arguments );
+    oldWrite.apply( stream, arguments );
     // Hook
     if ( arguments[ 0 ] === data ) {
-      clear_hook();
+      clearHook();
       cb();
     }
   };
@@ -43,7 +43,7 @@ var hook_stream = function( stream, data, cb ) {
 
 gulp.task("sass", function () {
   return gulp.src("./src/styles/**/*.scss")
-    .pipe(sass.sync({outputStyle: 'expanded'}).on('error', sass.logError))
+    .pipe(sass.sync({outputStyle: "expanded"}).on("error", sass.logError))
     .pipe(autoprefixer())
     .pipe(gulp.dest("./dist/css"));
 });
@@ -74,10 +74,12 @@ gulp.task("dev-server", function(callback) {
       colors: true
     }
   }).listen(port, host, function(err) {
-     hook_stream( process.stdout, 'webpack: bundle is now VALID.\n', function() {
-        gutil.log( '[dev-server]', gutil.colors.yellow( 'http://' + host + ':' + port + '/website/#/dev' ) );
-      } );
+    hookStream( process.stdout, "webpack: bundle is now VALID.\n", function() {
+      gutil.log("[dev-server]", gutil.colors.yellow("http://" + host + ":" + port + "/website/#/dev"));
+    });
 
-    if(err) throw new gutil.PluginError("webpack-dev-server", err);
+    if (err) {
+      throw new gutil.PluginError("webpack-dev-server", err);
+    }
   });
 });

--- a/makewebpackconfig.js
+++ b/makewebpackconfig.js
@@ -1,7 +1,5 @@
-var webpack = require("webpack");
-var merge = require("merge");
-var path = require("path");
-
+const merge = require("merge");
+const path = require("path");
 
 const defaultConfig = {
   entry: [
@@ -18,7 +16,7 @@ const defaultConfig = {
     contentBase: "./"
   },
   resolve: {
-    extensions: [ '', '.js', '.jsx' ],
+    extensions: ["", ".js", ".jsx"],
     fallback: path.join(__dirname, "node_modules")
   },
   resolveLoader: {
@@ -36,14 +34,14 @@ const defaultConfig = {
       },
       {
         test: /\.json$/,
-        loader: 'json'
+        loader: "json"
       }
     ]
   }
 };
 
 function makeConfig (extra) {
-  var config = merge.recursive(true, defaultConfig, extra || {});
+  const config = merge.recursive(true, defaultConfig, extra || {});
 
   return config;
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "build": "npm run build:lib && gulp sass && gulp sass-copy",
     "prepublish": "npm run build",
     "site": "webpack --config webpack.config.site.js --optimize-minimize && gulp site-sass",
-    "lint": "eslint src tests website",
+    "lint": "eslint ./*.js src tests website",
     "lint:watch": "esw -w src tests website",
     "watch": "babel -d lib/ src/ --watch"
   },

--- a/tests.webpack.js
+++ b/tests.webpack.js
@@ -4,5 +4,5 @@
  * License: MIT
  */
 
-var context = require.context('./tests', true, /^.*\_test.js$/);
+const context = require.context("./tests", true, /^.*\_test.js$/);
 context.keys().forEach(context);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,3 @@
-var makeConfig = require("./makewebpackconfig.js");
+const makeConfig = require("./makewebpackconfig.js");
 
 module.exports = makeConfig();

--- a/webpack.config.site.js
+++ b/webpack.config.site.js
@@ -1,13 +1,13 @@
-var webpack = require("webpack");
-var makeConfig = require("./makewebpackconfig.js");
+const webpack = require("webpack");
+const makeConfig = require("./makewebpackconfig.js");
 
 module.exports = makeConfig({
   plugins: [
-      new webpack.DefinePlugin({
-        "process.env": {
-          NODE_ENV: JSON.stringify("production")
-        }
-      })
+    new webpack.DefinePlugin({
+      "process.env": {
+        NODE_ENV: JSON.stringify("production")
+      }
+    })
   ],
   output: {
     filename: "./bundle.js"


### PR DESCRIPTION
As suggested on the megadraft's eslint config: https://github.com/globocom/megadraft/blob/master/.eslintrc#L19

No "var"s should be used on the code, including on configs and on gulpfile.

This PR replaces "var" with the "const" keyword (no "let" was required).
