### PR TITLE
pass props to draft-js editor component

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -185,7 +185,25 @@ export default class MegadraftEditor extends Component {
   }
 
   render() {
-    const {editorState, stripPastedStyles, spellCheck} = this.props;
+    const {
+      editorState,
+      stripPastedStyles,
+      spellCheck,
+      placeholder,
+      textAlignment,
+      blockRenderMap,
+      customStyleMap,
+      customStyleFn,
+      tabIndex,
+      handleBeforeInput,
+      handlePastedText,
+      handlePastedFiles,
+      handleDroppedFiles,
+      handleDrop,
+      onEscape,
+      onUpArrow,
+      onDownArrow,
+    } = this.props;
     const plugins = this.plugins;
 
     return (
@@ -204,7 +222,7 @@ export default class MegadraftEditor extends Component {
             ref="draft"
             readOnly={this.state.readOnly}
             plugins={plugins}
-            blockRenderMap={this.props.blockRenderMap}
+            blockRenderMap={blockRenderMap}
             blockRendererFn={this.mediaBlockRenderer}
             blockStyleFn={this.blockStyleFn}
             onTab={this.onTab}
@@ -214,7 +232,19 @@ export default class MegadraftEditor extends Component {
             spellCheck={spellCheck}
             keyBindingFn={this.externalKeyBindings}
             editorState={editorState}
-            placeholder={this.props.placeholder}
+            placeholder={placeholder}
+            textAlignment={textAlignment}
+            customStyleMap={customStyleMap}
+            customStyleFn={customStyleFn}
+            tabIndex={tabIndex}
+            handleBeforeInput={handleBeforeInput}
+            handlePastedText={handlePastedText}
+            handlePastedFiles={handlePastedFiles}
+            handleDroppedFiles={handleDroppedFiles}
+            handleDrop={handleDrop}
+            onEscape={onEscape}
+            onUpArrow={onUpArrow}
+            onDownArrow={onDownArrow}
             onChange={this.onChange} />
           {this.renderToolbar({
             editor: this.refs.editor,

--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -185,27 +185,6 @@ export default class MegadraftEditor extends Component {
   }
 
   render() {
-    const {
-      editorState,
-      stripPastedStyles,
-      spellCheck,
-      placeholder,
-      textAlignment,
-      blockRenderMap,
-      customStyleMap,
-      customStyleFn,
-      tabIndex,
-      handleBeforeInput,
-      handlePastedText,
-      handlePastedFiles,
-      handleDroppedFiles,
-      handleDrop,
-      onEscape,
-      onUpArrow,
-      onDownArrow,
-    } = this.props;
-    const plugins = this.plugins;
-
     return (
       <div className="megadraft">
         <div
@@ -213,42 +192,27 @@ export default class MegadraftEditor extends Component {
           id="megadraft-editor"
           ref="editor">
           {this.renderSidebar({
-            plugins,
-            editorState,
+            plugins: this.plugins,
+            editorState: this.props.editorState,
             readOnly: this.state.readOnly,
             onChange: this.onChange
           })}
           <Editor
+            {...this.props}
             ref="draft"
             readOnly={this.state.readOnly}
-            plugins={plugins}
-            blockRenderMap={blockRenderMap}
+            plugins={this.plugins}
             blockRendererFn={this.mediaBlockRenderer}
             blockStyleFn={this.blockStyleFn}
             onTab={this.onTab}
             handleKeyCommand={this.handleKeyCommand}
             handleReturn={this.handleReturn}
-            stripPastedStyles={stripPastedStyles}
-            spellCheck={spellCheck}
             keyBindingFn={this.externalKeyBindings}
-            editorState={editorState}
-            placeholder={placeholder}
-            textAlignment={textAlignment}
-            customStyleMap={customStyleMap}
-            customStyleFn={customStyleFn}
-            tabIndex={tabIndex}
-            handleBeforeInput={handleBeforeInput}
-            handlePastedText={handlePastedText}
-            handlePastedFiles={handlePastedFiles}
-            handleDroppedFiles={handleDroppedFiles}
-            handleDrop={handleDrop}
-            onEscape={onEscape}
-            onUpArrow={onUpArrow}
-            onDownArrow={onDownArrow}
-            onChange={this.onChange} />
+            onChange={this.onChange}
+          />
           {this.renderToolbar({
             editor: this.refs.editor,
-            editorState,
+            editorState: this.props.editorState,
             readOnly: this.state.readOnly,
             onChange: this.onChange,
             actions: this.actions,

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -111,6 +111,30 @@ describe("MegadraftEditor Component", () => {
     expect(items).to.have.length(1);
   });
 
+  it("passes extra props to the draft-js editor", function() {
+    const handlePastedText = (text) => { console.log(text); };
+    const wrapper = mount(
+      <MegadraftEditor
+        editorState={this.editorState}
+        onChange={this.onChange}
+        handlePastedText={handlePastedText}
+      />
+    );
+    expect(wrapper.ref("draft").props().handlePastedText).to.equal(handlePastedText);
+  });
+
+  it("cant overridde megadraft props via extra props", function() {
+    const blockRendererFn = (text) => { console.log(text); };
+    const wrapper = mount(
+      <MegadraftEditor
+        editorState={this.editorState}
+        onChange={this.onChange}
+        blockRendererFn={blockRendererFn}
+      />
+    );
+    expect(wrapper.ref("draft").props().blockRendererFn).to.not.equal(blockRendererFn);
+  });
+
   describe("mediaBlockRenderer", function () {
     it("ignores non-atomic blocks", function() {
       const block = {getType: function() {return "metal";}};


### PR DESCRIPTION
hello, i added the passing of the [native props](https://facebook.github.io/draft-js/docs/api-reference-editor.html) to the draft-js editor.
To be able to set handlePastedText for instance