### PR TITLE
Upgrading to draft-js 0.10.0 and to the new Entity API

### DIFF
--- a/docs/custom_entities.md
+++ b/docs/custom_entities.md
@@ -194,7 +194,8 @@ import {DraftJS} from "draft-js";
 
 
 export default ({entityKey, children}) => {
-  const {url} = DraftJS.Entity.get(this.props.entityKey).getData();
+  const contentState = this.props.contentState;
+  const {url} = contentState.getEntity(this.props.entityKey).getData();
   return (
     <a className="editor__link" href={url} title={url}>
       {children}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/Megadraft.js",
   "dependencies": {
     "classnames": "^2.2.5",
-    "draft-js": "0.9.1",
+    "draft-js": "0.10.0",
     "immutable": "^3.8.1",
     "setimmediate": "^1.0.4"
   },

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -5,12 +5,12 @@
  */
 
 import React, {Component} from "react";
-import {Entity} from "draft-js";
 
 
 export default class Link extends Component {
   render() {
-    const {url} = Entity.get(this.props.entityKey).getData();
+    const contentState = this.props.contentState;
+    const {url} = contentState.getEntity(this.props.entityKey).getData();
     return (
       <a className="editor__link" href={url} title={url}>
         {this.props.children}

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -5,7 +5,7 @@
  */
 
 import React, {Component} from "react";
-import {EditorState, RichUtils, Entity} from "draft-js";
+import {EditorState, RichUtils} from "draft-js";
 import classNames from "classnames";
 import ToolbarItem from "./ToolbarItem";
 import {getSelectionCoords} from "../utils";
@@ -159,7 +159,9 @@ export default class Toolbar extends Component {
 
   setEntity(entityType, data, mutability = "MUTABLE") {
     const {editorState} = this.props;
-    const entityKey = Entity.create(entityType, mutability, data);
+    const contentState = editorState.getCurrentContent();
+    const contentStateWithEntity = contentState.createEntity(entityType, mutability, data);
+    const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
     const newState = RichUtils.toggleLink(
       editorState,
       editorState.getSelection(),

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -141,9 +141,10 @@ export default class Toolbar extends Component {
   }
 
   getCurrentEntity() {
+    const contentState = this.props.editorState.getCurrentContent();
     const entityKey = this.getCurrentEntityKey();
     if(entityKey) {
-      return Entity.get(entityKey);
+      return contentState.getEntity(entityKey);
     }
     return null;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,6 @@
  */
 
 import {
-  Entity,
   convertToRaw,
   convertFromRaw,
   EditorState,
@@ -65,13 +64,13 @@ export function getSelectionCoords(editor, toolbar) {
 }
 
 export function createTypeStrategy(type) {
-  return (contentBlock, callback) => {
+  return (contentBlock, callback, contentState) => {
     contentBlock.findEntityRanges(
       (character) => {
         const entityKey = character.getEntity();
         return (
           entityKey !== null &&
-          Entity.get(entityKey).getType() === type
+          contentState.getEntity(entityKey).getType() === type
         );
       },
       callback

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -5,7 +5,7 @@
  */
 
 import React, {Component} from "react";
-import {EditorState, SelectionState, Entity} from "draft-js";
+import {EditorState, SelectionState} from "draft-js";
 import chai from "chai";
 import {mount} from "enzyme";
 
@@ -238,7 +238,7 @@ describe("Toolbar Component", function() {
         const contentState = this.wrapper.state("editorState").getCurrentContent();
         const blockWithLinkAtBeginning = contentState.getBlockForKey("ag6qs");
         const linkKey = blockWithLinkAtBeginning.getEntityAt(0);
-        const linkInstance = Entity.get(linkKey);
+        const linkInstance = contentState.getEntity(linkKey);
         const {url} = linkInstance.getData();
 
         expect(url).to.be.equal("http://www.globo.com");


### PR DESCRIPTION
Hi,

draft-js 0.10.0 contains a new feature that I miss today, the ability to paste paragraphs from HTML or Word while keeping their structure.
See the pull request merged in 0.10.0 : https://github.com/facebook/draft-js/pull/828

So I propose the upgrading from 0.9.1 to 0.10.0. This is not a breaking change (see  https://github.com/facebook/draft-js/issues/839 ), I've only seen warnings, that I fixed with replacing some instructions with the new API.

Entity.get(entityKey)

become

contentState.getEntity(entityKey)

Tests are ok !

I hope you'll be able to merge this soon !