### PR TITLE
fix plugin readonly state

### DIFF
--- a/src/components/Media.js
+++ b/src/components/Media.js
@@ -61,10 +61,15 @@ export default class Media extends Component {
   render() {
     // Should we use immutables?
     const data = this.props.block.getData().toJS();
-    const {plugin, setReadOnly} = this.props.blockProps;
+    const {plugin,
+      setInitialReadOnly,
+      setReadOnly} = this.props.blockProps;
     const Block = plugin.blockComponent;
     return (
-      <MediaWrapper setReadOnly={setReadOnly}>
+      <MediaWrapper
+        setInitialReadOnly={setInitialReadOnly}
+        setReadOnly={setReadOnly}
+      >
         <Block data={data} container={this} blockProps={this.props.blockProps} />
       </MediaWrapper>
     );

--- a/src/components/MediaWrapper.js
+++ b/src/components/MediaWrapper.js
@@ -17,11 +17,13 @@ export default class MediaWrapper extends Component {
   }
 
   _handleFocus() {
+    // temporarily set the editor to readonly
     this.props.setReadOnly(true);
   }
 
   _handleBlur() {
-    this.props.setReadOnly(false);
+    // restore readonly to its original state
+    this.props.setInitialReadOnly();
   }
 
   render() {

--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -48,6 +48,9 @@ export default class MegadraftEditor extends Component {
     this.handleReturn = ::this.handleReturn;
 
     this.setReadOnly = ::this.setReadOnly;
+    this.getReadOnly = ::this.getReadOnly;
+    this.getInitialReadOnly = ::this.getInitialReadOnly;
+    this.setInitialReadOnly = ::this.setInitialReadOnly;
 
     this.externalKeyBindings = ::this.externalKeyBindings;
 
@@ -233,6 +236,19 @@ export default class MegadraftEditor extends Component {
     this.setState({readOnly});
   }
 
+  getReadOnly() {
+    return this.state.readOnly;
+  }
+
+  getInitialReadOnly() {
+    return this.props.readOnly || false;
+  }
+
+  setInitialReadOnly() {
+    let readOnly = this.props.readOnly || false;
+    this.setState({readOnly});
+  }
+
   handleBlockNotFound(block) {
     if (this.props.handleBlockNotFound) {
       return this.props.handleBlockNotFound(block);
@@ -259,7 +275,10 @@ export default class MegadraftEditor extends Component {
         plugin: plugin,
         onChange: this.onChange,
         editorState: this.props.editorState,
-        setReadOnly: this.setReadOnly
+        setReadOnly: this.setReadOnly,
+        getReadOnly: this.getReadOnly,
+        getInitialReadOnly: this.getInitialReadOnly,
+        setInitialReadOnly: this.setInitialReadOnly
       }
     };
   }

--- a/tests/components/MediaWrapper_test.js
+++ b/tests/components/MediaWrapper_test.js
@@ -16,9 +16,10 @@ let expect = chai.expect;
 describe("MediaWrapper", function() {
   beforeEach(function() {
     this.setReadOnly = sinon.spy();
+    this.setInitialReadOnly = sinon.spy();
 
     this.wrapper = mount(
-      <MediaWrapper setReadOnly={this.setReadOnly}>
+      <MediaWrapper setReadOnly={this.setReadOnly} setInitialReadOnly={this.setInitialReadOnly}>
         <input type="text" />
       </MediaWrapper>
     );
@@ -31,8 +32,8 @@ describe("MediaWrapper", function() {
     expect(this.setReadOnly.calledWith(true)).to.be.true;
   });
 
-  it("disables readOnly on input blur", function () {
+  it("restores readOnly on input blur", function () {
     this.input.simulate("blur");
-    expect(this.setReadOnly.calledWith(false)).to.be.true;
+    expect(this.setInitialReadOnly.called).to.be.true;
   });
 });

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -304,7 +304,10 @@ describe("MegadraftEditor Component", () => {
           "plugin": image,
           "onChange": this.component.onChange,
           "editorState": this.editorState,
-          "setReadOnly": this.component.setReadOnly
+          "setReadOnly": this.component.setReadOnly,
+          "getReadOnly": this.component.getReadOnly,
+          "setInitialReadOnly": this.component.setInitialReadOnly,
+          "getInitialReadOnly": this.component.getInitialReadOnly,
         }
       });
     });
@@ -320,7 +323,10 @@ describe("MegadraftEditor Component", () => {
           "plugin": NotFoundPlugin,
           "onChange": this.component.onChange,
           "editorState": this.editorState,
-          "setReadOnly": this.component.setReadOnly
+          "setReadOnly": this.component.setReadOnly,
+          "getReadOnly": this.component.getReadOnly,
+          "setInitialReadOnly": this.component.setInitialReadOnly,
+          "getInitialReadOnly": this.component.getInitialReadOnly,
         }
       });
     });
@@ -341,7 +347,10 @@ describe("MegadraftEditor Component", () => {
           "plugin": customFallbackPlugin,
           "onChange": this.component.onChange,
           "editorState": this.editorState,
-          "setReadOnly": this.component.setReadOnly
+          "setReadOnly": this.component.setReadOnly,
+          "getReadOnly": this.component.getReadOnly,
+          "setInitialReadOnly": this.component.setInitialReadOnly,
+          "getInitialReadOnly": this.component.getInitialReadOnly,
         }
       });
     });


### PR DESCRIPTION
This should solve the following issues:
#97 
#86 

Problem Summary: 

1. When plugins receive focus, the onFocus event sets the parent editor to readonly=true to prevent state changes in editor outside of plugin. When plugin loses focus, onBlur for the plugin sets parent editor to readonly=false regardless of what the original state of the editor was.
2. At a plugin level, there is no easy way to determine whether the plugin should be readonly or not, which means that some plugins will have some unexpected inputs enabled even when the editor is readonly=true. 

Proposed Solution: 
Expose additional methods to the plugins through blockProps:

- getReadOnly() - Sister function to setReadOnly (only method currently exposed), gets the current readonly value from the editor **state**
- getInitialReadOnly() - Like getReadOnly, except grabs the readonly state from the editor  **props**. This will allow the plugin to access the _permanent_ readonly state of the editor.
- setInitialReadonly() - Restores the state of the editor back to what is in the props. This like the original setReadOnly function, except it does not accept an input and **only** uses **props**.

getInitialReadOnly and setInitialReadOnly address shortcomings of the readonly features at plugin by giving plugins more visibility into editor state, and solve any state change restoration problems. 