### PR TITLE
"Toolbar show" behaviour can be set via an optional predicate function

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -28,6 +28,8 @@ Here are the props that `MegadraftEditor` accepts:
   and when clicked it will open a modal window with the full button list.
 - `modalOptions`: (optional) object, height and width of the modal.
   Check the following sections for more info.
+- `onToolbarShowRequest`: (optional) Predicate function fired when
+  editor state changes
 
 Check the following sections for more info.
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -28,8 +28,8 @@ Here are the props that `MegadraftEditor` accepts:
   and when clicked it will open a modal window with the full button list.
 - `modalOptions`: (optional) object, height and width of the modal.
   Check the following sections for more info.
-- `onToolbarShowRequest`: (optional) Predicate function fired when
-  editor state changes
+- `shouldDisplayToolbarFn`: (optional) Boolean-valued function fired when
+  editor state changes. It allows to control whether or not the Toolbar should be shown.
 
 Check the following sections for more info.
 

--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -337,7 +337,8 @@ export default class MegadraftEditor extends Component {
             readOnly: this.state.readOnly,
             onChange: this.onChange,
             actions: this.actions,
-            entityInputs: this.entityInputs
+            entityInputs: this.entityInputs,
+            onToolbarShowRequest: this.props.onToolbarShowRequest,
           })}
         </div>
       </div>

--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -338,7 +338,7 @@ export default class MegadraftEditor extends Component {
             onChange: this.onChange,
             actions: this.actions,
             entityInputs: this.entityInputs,
-            onToolbarShowRequest: this.props.onToolbarShowRequest,
+            shouldDisplayToolbarFn: this.props.shouldDisplayToolbarFn,
           })}
         </div>
       </div>

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -13,7 +13,7 @@ import {getSelectionCoords} from "../utils";
 
 export default class Toolbar extends Component {
   static defaultProps = {
-    onToolbarShowRequest() {
+    shouldDisplayToolbarFn() {
       return !this.editorState.getSelection().isCollapsed();
     },
   }
@@ -122,7 +122,7 @@ export default class Toolbar extends Component {
   }
 
   componentDidUpdate() {
-    if (this.props.onToolbarShowRequest()) {
+    if (this.props.shouldDisplayToolbarFn()) {
       return this.setBarPosition();
     } else {
       if (this.state.show) {

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -12,6 +12,12 @@ import {getSelectionCoords} from "../utils";
 
 
 export default class Toolbar extends Component {
+  static defaultProps = {
+    onToolbarShowRequest() {
+      return !this.editorState.getSelection().isCollapsed();
+    },
+  }
+
   constructor(props) {
     super(props);
     this.state = {
@@ -116,7 +122,7 @@ export default class Toolbar extends Component {
   }
 
   componentDidUpdate() {
-    if (!this.props.editorState.getSelection().isCollapsed()) {
+    if (this.props.onToolbarShowRequest()) {
       return this.setBarPosition();
     } else {
       if (this.state.show) {


### PR DESCRIPTION
This PR allows self defined "toolbar show" behaviour. The legacy behaviour is preserved as a default prop.

For instance, if you wished to force the toolbar to be allows shown you can now write:

```js
<MegadraftEditor
  // ...
  onToolbarShowRequest={() => true}
  // ...
/>
```