### PR TITLE
Ability to create custom actions in Toolbar

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -110,14 +110,14 @@ class App extends React.Component {
   }
 
   render() {
-    const custom_actions = actions.concat([
+    const customActions = actions.concat([
       {type: "inline", label: "U", style: "UNDERLINE", icon: UnderlineIcon}
     ]);
     return (
       <MegadraftEditor
         editorState={this.state.editorState}
         onChange={this.onChange}
-        actions={custom_actions}/>
+        actions={customActions}/>
     )
   }
 }
@@ -136,18 +136,18 @@ ReactDOM.render(
 );
 ```
 
-You can also provide a fully custom action :
+You can also provide a fully custom action:
 
 ```js
-const custom_actions = [
+const customActions = [
   {
-    type: 'custom',
+    type: "custom",
     icon: OwnIcon,
     action() {
       // Here goes the code triggered on button click
     },
   },
-]
+];
 ```
 
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -136,6 +136,20 @@ ReactDOM.render(
 );
 ```
 
+You can also provide a fully custom action :
+
+```js
+const custom_actions = [
+  {
+    type: 'custom',
+    icon: OwnIcon,
+    action() {
+      // Here goes the code triggered on button click
+    },
+  },
+]
+```
+
 
 ## Toolbar component
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -56,7 +56,7 @@ export default class Toolbar extends Component {
 
     switch(item.type) {
       case "custom": {
-        toggle = item.action;
+        toggle = () => item.action(this.props.editorState);
         break;
       }
       case "inline": {

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -55,6 +55,10 @@ export default class Toolbar extends Component {
     let key = item.label;
 
     switch(item.type) {
+      case "custom": {
+        toggle = item.action;
+        break;
+      }
       case "inline": {
         current = this.props.editorState.getCurrentInlineStyle();
         toggle = () => this.toggleInlineStyle(item.style);
@@ -243,6 +247,7 @@ export default class Toolbar extends Component {
     if(this.props.readOnly) {
       return null;
     }
+
     const toolbarClass = classNames("toolbar", {
       "toolbar--open": this.state.show,
       "toolbar--error": this.state.error

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -161,10 +161,12 @@ describe("Toolbar Component", function() {
         const items = this.wrapper.find(ToolbarItem);
         const customItem = items.at(5);
         const button = customItem.find("button");
+        const editorState = this.wrapper.state("editorState");
 
         button.simulate("click");
 
         expect(this.actions[5].action).to.have.been.called;
+        expect(this.actions[5].action).to.have.been.calledWith(editorState);
       });
     });
 

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -7,6 +7,7 @@
 import React, {Component} from "react";
 import {EditorState, SelectionState} from "draft-js";
 import chai from "chai";
+import sinon from "sinon";
 import {mount} from "enzyme";
 
 import Toolbar from "../../src/components/Toolbar";
@@ -93,7 +94,8 @@ describe("Toolbar Component", function() {
       {type: "separator"},
       {type: "block", label: "H2", style: "header-two", icon: "svg"},
       {type: "entity", label: "Link", style: "link", entity: "LINK", icon: "svg"},
-      {type: "entity", label: "File", style: "link", entity: "FILE_LINK", icon: "svg"}
+      {type: "entity", label: "File", style: "link", entity: "FILE_LINK", icon: "svg"},
+      {type: "custom", icon: "svg", action: sinon.spy()}
     ];
 
     this.entityInputs = {
@@ -153,6 +155,16 @@ describe("Toolbar Component", function() {
           .getType();
 
         expect(current).to.be.equal("header-two");
+      });
+
+      it("triggers custom action", function() {
+        const items = this.wrapper.find(ToolbarItem);
+        const customItem = items.at(5);
+        const button = customItem.find("button");
+
+        button.simulate("click");
+
+        expect(this.actions[5].action).to.have.been.called;
       });
     });
 


### PR DESCRIPTION
The Toolbar actions seem to be all related to DraftJS styles and entities, which is fine, but comes short when deep changes are needed (like cutting a selection, replacing it, inserting ContentBlock, etc...).

This PR attempts to be more permissive regarding the Toolbar actions.