### PR TITLE
Ability to change toolbar actions on the fly

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -54,7 +54,6 @@ export default class MegadraftEditor extends Component {
 
     this.externalKeyBindings = ::this.externalKeyBindings;
 
-    this.actions = this.props.actions || DEFAULT_ACTIONS;
     this.plugins = this.getValidPlugins();
     this.entityInputs = this.props.entityInputs || DEFAULT_ENTITY_INPUTS;
     this.blocksWithoutStyleReset = (this.props.blocksWithoutStyleReset ||
@@ -336,7 +335,7 @@ export default class MegadraftEditor extends Component {
             editorState: this.props.editorState,
             readOnly: this.state.readOnly,
             onChange: this.onChange,
-            actions: this.actions,
+            actions: this.props.actions || DEFAULT_ACTIONS,
             entityInputs: this.entityInputs,
             shouldDisplayToolbarFn: this.props.shouldDisplayToolbarFn,
           })}

--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -34,6 +34,10 @@ const NO_RESET_STYLE_DEFAULT = ["ordered-list-item", "unordered-list-item"];
 
 
 export default class MegadraftEditor extends Component {
+  static defaultProps = {
+    actions: DEFAULT_ACTIONS,
+  }
+
   constructor(props) {
     super(props);
     this.state = {
@@ -335,7 +339,7 @@ export default class MegadraftEditor extends Component {
             editorState: this.props.editorState,
             readOnly: this.state.readOnly,
             onChange: this.onChange,
-            actions: this.props.actions || DEFAULT_ACTIONS,
+            actions: this.props.actions,
             entityInputs: this.entityInputs,
             shouldDisplayToolbarFn: this.props.shouldDisplayToolbarFn,
           })}

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -598,6 +598,7 @@ describe("MegadraftEditor Component", () => {
     const toolbar = this.wrapper.find(Toolbar);
     // editor is undefined :-/
     //expect(toolbar.prop("editor")).to.equal(this.component.refs.editor);
+    expect(toolbar.prop("actions")).to.equal(this.component.props.actions);
     expect(toolbar.prop("entityInputs")).to.equal(this.component.entityInputs);
     expect(toolbar.prop("onChange")).to.equal(this.component.onChange);
     expect(toolbar.prop("editorState")).to.equal(this.editorState);
@@ -623,6 +624,7 @@ describe("MegadraftEditor Component", () => {
     );
     const toolbar = wrapper.find(MyCustomToolbar);
     expect(toolbar).to.have.length(1);
+    expect(toolbar.prop("actions")).to.equal(this.component.props.actions);
     expect(toolbar.prop("entityInputs")).to.equal(this.component.entityInputs);
     expect(toolbar.prop("editorState")).to.equal(this.editorState);
     expect(toolbar.prop("readOnly")).to.equal(false);

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -598,7 +598,6 @@ describe("MegadraftEditor Component", () => {
     const toolbar = this.wrapper.find(Toolbar);
     // editor is undefined :-/
     //expect(toolbar.prop("editor")).to.equal(this.component.refs.editor);
-    expect(toolbar.prop("actions")).to.equal(this.component.actions);
     expect(toolbar.prop("entityInputs")).to.equal(this.component.entityInputs);
     expect(toolbar.prop("onChange")).to.equal(this.component.onChange);
     expect(toolbar.prop("editorState")).to.equal(this.editorState);
@@ -624,7 +623,6 @@ describe("MegadraftEditor Component", () => {
     );
     const toolbar = wrapper.find(MyCustomToolbar);
     expect(toolbar).to.have.length(1);
-    expect(toolbar.prop("actions")).to.equal(this.component.actions);
     expect(toolbar.prop("entityInputs")).to.equal(this.component.entityInputs);
     expect(toolbar.prop("editorState")).to.equal(this.editorState);
     expect(toolbar.prop("readOnly")).to.equal(false);


### PR DESCRIPTION
This PR allows to change the toolbar actions on the fly.

As a downside, the actions are not "cached" in a MegadraftEditor Component attribute anymore.