### PR TITLE
Add --open classnames to sidemenu

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -86,7 +86,7 @@ class BlockStyles extends Component {
     // We should hide the modal if the number of plugins < max
     const hasModal = this.props.plugins.length > maxSidebarButtons;
     const className = classNames("sidemenu__items", {
-      "sidemenu__items--open": this.state.open
+      "sidemenu__items--open": this.state.isOpen
     });
     return (
       <div>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -86,7 +86,7 @@ class BlockStyles extends Component {
     // We should hide the modal if the number of plugins < max
     const hasModal = this.props.plugins.length > maxSidebarButtons;
     const className = classNames("sidemenu__items", {
-      "sidemenu__items--open": this.state.isOpen
+      "sidemenu__items--open": this.props.open
     });
     return (
       <div>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -85,10 +85,12 @@ class BlockStyles extends Component {
 
     // We should hide the modal if the number of plugins < max
     const hasModal = this.props.plugins.length > maxSidebarButtons;
-
+    const className = classNames("sidemenu__items", {
+      "sidemenu__items--open": this.state.open
+    });
     return (
       <div>
-        <ul style={sidemenuMaxHeight} className="sidemenu__items">
+        <ul style={sidemenuMaxHeight} className={className}>
           {this.props.plugins.slice(0, maxSidebarButtons).map(this.renderButton)}
           {hasModal ? this.renderModalButton() : null}
         </ul>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -135,8 +135,11 @@ export class SideMenu extends Component {
   }
 
   render() {
+    const className = classNames("sidemenu", {
+      "sidemenu--open": this.state.open
+    });
     return (
-      <li className="sidemenu">
+      <li className={className}>
         <ToggleButton
           toggle={this.toggle}
           open={this.state.open} />


### PR DESCRIPTION
just a small one,

we show larger buttons there and its currently not possible to do an overflow, because 
there is no class when the sidemenu is open.

i added in on both sidemenu and sidemenu__items (&--open). sidemenu__items--open had already been there in a previous version but was removed as it seems. 