### PR TITLE
Allow blockStyleFn to be overridden

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -327,7 +327,7 @@ export default class MegadraftEditor extends Component {
             readOnly={this.state.readOnly}
             plugins={this.plugins}
             blockRendererFn={this.mediaBlockRenderer}
-            blockStyleFn={this.blockStyleFn}
+            blockStyleFn={this.props.blockStyleFn || this.blockStyleFn}
             onTab={this.onTab}
             handleKeyCommand={this.handleKeyCommand}
             handleReturn={this.props.handleReturn || this.handleReturn}

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -201,6 +201,18 @@ describe("MegadraftEditor Component", () => {
     expect(wrapper.ref("draft").props().blockRendererFn).to.not.equal(blockRendererFn);
   });
 
+  it("allows blockStyleFn to be overridden", function() {
+    const blockStyleFn = (text) => { console.log(text); };
+    const wrapper = mount(
+      <MegadraftEditor
+        editorState={this.editorState}
+        onChange={this.onChange}
+        blockStyleFn={blockStyleFn}
+      />
+    );
+    expect(wrapper.ref("draft").props().blockStyleFn).to.equal(blockStyleFn);
+  });
+
   it("reset blockStyle in new block if resetStyle is true", function() {
     const blockKey = "ag6qs";
     replaceSelection(


### PR DESCRIPTION
I'd like to propose the following change to allow `blockStyleFn` to be overridden. For example:

```
        <MegadraftEditor
          plugins={[image, video]}
          editorState={this.state.value}
          onChange={this.onChange}
          blockStyleFn={(contentBlock) => {
            const type = contentBlock.getType();
            if (type === "header-two") {
              return "my-header-class";
            }
          }} />
```

If `blockStyleFn` is not supplied the [default method](https://github.com/andrewb/megadraft/blob/d416fcd5c351fe50181d8ac9810444f9bbab6024/src/components/MegadraftEditor.js#L289) is used.

I am using a custom `blockRenderMap` and without this change I cannot add classes to new block types (e.g. blocks for text alignment).