### PR TITLE
Add a prop for disabling dropdown expansion for single item dropdowns

### DIFF
--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -23,7 +23,8 @@ export default class Dropdown extends Component {
       })
     ),
     selected: PropTypes.string,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    disableForSingleItem: PropTypes.bool
   }
 
   constructor(props) {
@@ -40,6 +41,11 @@ export default class Dropdown extends Component {
   isEmpty() {
     const items = this.props.items || [];
     return (items.length == 0) ? true : false;
+  }
+
+  isSingleItem() {
+    const items = this.props.items || [];
+    return (items.length == 1) ? true : false;
   }
 
   onChange(selected) {
@@ -62,6 +68,9 @@ export default class Dropdown extends Component {
   }
 
   toggleDropDown(event) {
+    if(this.isSingleItem() && this.props.disableForSingleItem) {
+      return null;
+    }
     this.setState({isOpen: !this.state.isOpen});
   }
 
@@ -105,6 +114,9 @@ export default class Dropdown extends Component {
       "dropdown__arrow--open": isOpen
     });
 
+    const dropdownArrow = (<icons.DropdownArrow className={arrowClassName} />);
+    const dropdownSection = (this.isSingleItem() && this.props.disableForSingleItem) ? null : dropdownArrow;
+
     return(
       <div className={wrapperClassName} onClick={this.toggleDropDown}>
         <DropdownItem
@@ -112,7 +124,7 @@ export default class Dropdown extends Component {
           className="dropdown__item--selected"
           onMouseDown={this.preventSelection}>
 
-          <icons.DropdownArrow className={arrowClassName} />
+          {dropdownSection}
         </DropdownItem>
 
         <ul className={dropdownClassName}>

--- a/src/components/plugin/CommonBlock.js
+++ b/src/components/plugin/CommonBlock.js
@@ -44,6 +44,7 @@ export default class CommonBlock extends Component {
           <Dropdown
             items={options.displayOptions}
             selected={data.display || options.defaultDisplay}
+            disableForSingleItem={options.disableForSingleItem}
             onChange={this._handleDisplayChange} />
 
           <BlockActionGroup items={this.props.actions} />

--- a/tests/components/Dropdown_test.js
+++ b/tests/components/Dropdown_test.js
@@ -72,4 +72,26 @@ describe("Dropdown Component", function() {
     wrapper.simulate("click");
     expect(this.component.state("isOpen")).to.be.false;
   });
+
+  it("does not display a dropdown arrow for a single item when disableForSingleItem is true", function () {
+    
+    const selected = "jazz";
+    const onChange = sinon.spy();
+    const dropdownItems = [
+      {"key": "jazz", "icon": icons.MediaBigIcon, "label": "Jazz"}
+    ];
+
+    this.disabledDropdownComponent = mount(
+      <Dropdown
+        items={dropdownItems}
+        selected={selected}
+        onChange={onChange} 
+        disableForSingleItem={true} />
+    );
+    
+    const wrapper = this.disabledDropdownComponent.find("div").first();
+    wrapper.simulate("click");
+    expect(this.disabledDropdownComponent.state("isOpen")).to.be.false;
+
+  });
 });

--- a/tests/components/Dropdown_test.js
+++ b/tests/components/Dropdown_test.js
@@ -74,7 +74,7 @@ describe("Dropdown Component", function() {
   });
 
   it("does not display a dropdown arrow for a single item when disableForSingleItem is true", function () {
-    
+
     const selected = "jazz";
     const onChange = sinon.spy();
     const dropdownItems = [
@@ -85,10 +85,10 @@ describe("Dropdown Component", function() {
       <Dropdown
         items={dropdownItems}
         selected={selected}
-        onChange={onChange} 
+        onChange={onChange}
         disableForSingleItem={true} />
     );
-    
+
     const wrapper = this.disabledDropdownComponent.find("div").first();
     wrapper.simulate("click");
     expect(this.disabledDropdownComponent.state("isOpen")).to.be.false;


### PR DESCRIPTION
This solves two use cases for us:

1. For more or less 'labeling' some of our plugins with a description
2. For readonly versions of our plugins