### PR TITLE
Toggle modal visibility when a plugin button trigger onChange function

### DIFF
--- a/src/components/ModalPluginList.js
+++ b/src/components/ModalPluginList.js
@@ -14,10 +14,16 @@ export default class ModalPluginList extends Component {
   constructor(props) {
     super(props);
     this.modalClose = ::this.modalClose;
+    this.onChange = ::this.onChange;
   }
 
   modalClose() {
     this.props.toggleModalVisibility();
+  }
+
+  onChange() {
+    this.props.toggleModalVisibility();
+    this.props.onChange(...arguments);
   }
 
   render() {
@@ -27,7 +33,7 @@ export default class ModalPluginList extends Component {
         <ModalPluginItem
           toggleModalVisibility={this.modalClose}
           plugins={this.props.plugins}
-          onChange={this.props.onChange}
+          onChange={this.onChange}
           editorState={this.props.editorState}
         />
       </ModalBody>

--- a/tests/components/modalpluginlist_test.js
+++ b/tests/components/modalpluginlist_test.js
@@ -31,27 +31,18 @@ class ModalWithPlugins extends Component {
   }
 
   onChange(editorState) {
+    this.props.onChange(editorState);
     this.setState({editorState: editorState});
   }
 
   render() {
-    let onChange = this.onChange;
-    if (this.props.onChange) {
-      onChange = this.props.onChange;
-    }
-
-    let toggleModalVisibility = sinon.spy();
-    if (this.props.toggleModalVisibility) {
-      toggleModalVisibility = this.props.toggleModalVisibility;
-    }
-
     return (
       <div ref="editor">
         <ModalPluginList
           handleModal={this.handleModal}
           plugins={this.fakePlugins}
-          onChange={onChange}
-          toggleModalVisibility={toggleModalVisibility}
+          onChange={this.onChange}
+          toggleModalVisibility={this.props.toggleModalVisibility}
           editorState={this.props.editorState} />
       </div>
     );
@@ -59,9 +50,13 @@ class ModalWithPlugins extends Component {
 }
 
 describe("Sidebar Modal Component", function() {
+
   beforeEach(function() {
+    this.onChangeSpy = sinon.spy();
+    this.toggleModalVisibilitySpy = sinon.spy();
+
     this.wrapper = mount(
-      <ModalWithPlugins />
+      <ModalWithPlugins onChange={this.onChangeSpy} toggleModalVisibility={this.toggleModalVisibilitySpy}/>
     );
   });
 
@@ -91,24 +86,16 @@ describe("Sidebar Modal Component", function() {
   });
 
   it("should callback a function received when receives onChange call", function() {
-    const onChangeSpy = sinon.spy();
-    this.wrapper = mount(
-      <ModalWithPlugins onChange={onChangeSpy} />
-    );
     const newEditorState = {};
     const modal = this.wrapper.find(ModalPluginList);
     modal.getNode().onChange(newEditorState);
-    expect(onChangeSpy).to.be.calledWith(newEditorState);
+    expect(this.onChangeSpy).to.be.calledWith(newEditorState);
   });
 
   it("should toggle visibility when receives onChange call", function() {
-    const toggleModalVisibility = sinon.spy();
-    this.wrapper = mount(
-      <ModalWithPlugins toggleModalVisibility={toggleModalVisibility} />
-    );
     const newEditorState = {};
     const modal = this.wrapper.find(ModalPluginList);
     modal.getNode().onChange(newEditorState);
-    expect(toggleModalVisibility).to.be.called;
+    expect(this.toggleModalVisibilitySpy).to.be.called;
   });
 });

--- a/tests/components/modalpluginlist_test.js
+++ b/tests/components/modalpluginlist_test.js
@@ -6,6 +6,7 @@
 
 import React, {Component} from "react";
 import chai from "chai";
+import sinon from "sinon";
 import {mount} from "enzyme";
 import cp from "utils-copy";
 
@@ -34,12 +35,23 @@ class ModalWithPlugins extends Component {
   }
 
   render() {
+    let onChange = this.onChange;
+    if (this.props.onChange) {
+      onChange = this.props.onChange;
+    }
+
+    let toggleModalVisibility = sinon.spy();
+    if (this.props.toggleModalVisibility) {
+      toggleModalVisibility = this.props.toggleModalVisibility;
+    }
+
     return (
       <div ref="editor">
         <ModalPluginList
           handleModal={this.handleModal}
           plugins={this.fakePlugins}
-          onChange={this.onChange}
+          onChange={onChange}
+          toggleModalVisibility={toggleModalVisibility}
           editorState={this.props.editorState} />
       </div>
     );
@@ -76,5 +88,27 @@ describe("Sidebar Modal Component", function() {
     const plugin = modal.find("VideoButton");
 
     expect(plugin.length).to.be.at.least(1);
+  });
+
+  it("should callback a function received when receives onChange call", function() {
+    const onChangeSpy = sinon.spy();
+    this.wrapper = mount(
+      <ModalWithPlugins onChange={onChangeSpy} />
+    );
+    const newEditorState = {};
+    const modal = this.wrapper.find(ModalPluginList);
+    modal.getNode().onChange(newEditorState);
+    expect(onChangeSpy).to.be.calledWith(newEditorState);
+  });
+
+  it("should toggle visibility when receives onChange call", function() {
+    const toggleModalVisibility = sinon.spy();
+    this.wrapper = mount(
+      <ModalWithPlugins toggleModalVisibility={toggleModalVisibility} />
+    );
+    const newEditorState = {};
+    const modal = this.wrapper.find(ModalPluginList);
+    modal.getNode().onChange(newEditorState);
+    expect(toggleModalVisibility).to.be.called;
   });
 });


### PR DESCRIPTION
This fixes the scenario where a new modal is applied over the plugin list modal, making it still available when the current modal is closed.
This change will always close the modal when a plugin calls the onChange function, returning to the Megadraft main view.