### PR TITLE
Use ref callback instead of string

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -234,7 +234,7 @@ export default class MegadraftEditor extends Component {
   }
 
   focus() {
-    this.refs.draft.focus();
+    this.draftEl.focus();
   }
 
   setReadOnly(readOnly) {
@@ -314,7 +314,7 @@ export default class MegadraftEditor extends Component {
         <div
           className="megadraft-editor"
           id="megadraft-editor"
-          ref="editor">
+          ref={(el) => { this.editorEl = el; }}>
           {this.renderSidebar({
             plugins: this.plugins,
             editorState: this.props.editorState,
@@ -325,7 +325,7 @@ export default class MegadraftEditor extends Component {
           })}
           <Editor
             {...this.props}
-            ref="draft"
+            ref={(el) => { this.draftEl = el; }}
             readOnly={this.state.readOnly}
             plugins={this.plugins}
             blockRendererFn={this.mediaBlockRenderer}
@@ -337,7 +337,7 @@ export default class MegadraftEditor extends Component {
             onChange={this.onChange}
           />
           {this.renderToolbar({
-            editor: this.refs.editor,
+            editor: this.editorEl,
             editorState: this.props.editorState,
             readOnly: this.state.readOnly,
             onChange: this.onChange,

--- a/src/components/ModalPluginItem.js
+++ b/src/components/ModalPluginItem.js
@@ -16,7 +16,7 @@ export default class ModalPluginItem extends Component {
   }
 
   handleClick(e) {
-    this.myButton.onClick(e);
+    this.buttonEl.onClick(e);
   }
 
   closeModal() {
@@ -32,7 +32,7 @@ export default class ModalPluginItem extends Component {
         className="megadraft-modal__item"
         onClick={this.closeModal} >
         <Button
-          ref={(button)=>{this.myButton = button;}}
+          ref={(el)=>{this.buttonEl = el;}}
           className="megadraft-modal__button"
           title={item.title}
           editorState={this.props.editorState}

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -209,7 +209,7 @@ export default class SideBar extends Component {
   }
 
   setBarPosition() {
-    const container = ReactDOM.findDOMNode(this.refs.container);
+    const container = ReactDOM.findDOMNode(this.containerEl);
 
     const element = getSelectedBlockElement();
 
@@ -233,7 +233,7 @@ export default class SideBar extends Component {
       return null;
     }
     return (
-      <div ref="container" className="sidebar">
+      <div ref={(el) => { this.containerEl = el; }} className="sidebar">
         <div style={{top: `${this.state.top}px`}} className="sidebar__menu">
           <ul className="sidebar__sidemenu-wrapper">
             <SideMenu

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -104,8 +104,8 @@ export default class Toolbar extends Component {
 
   setBarPosition() {
     const editor = this.props.editor;
-    const toolbar = this.refs.toolbar;
-    const arrow = this.refs.arrow;
+    const toolbar = this.toolbarEl;
+    const arrow = this.arrowEl;
     const selectionCoords = getSelectionCoords(editor, toolbar);
 
     if (!selectionCoords) {
@@ -142,9 +142,9 @@ export default class Toolbar extends Component {
 
   componentDidUpdate() {
     // reset toolbar position every time
-    if (this.refs.toolbar && this.refs.arrow) {
-      this.refs.toolbar.style.left = "";
-      this.refs.arrow.style.left = "";
+    if (this.toolbarEl && this.arrowEl) {
+      this.toolbarEl.style.left = "";
+      this.arrowEl.style.left = "";
     }
     if (this.props.shouldDisplayToolbarFn()) {
       return this.setBarPosition();
@@ -274,18 +274,16 @@ export default class Toolbar extends Component {
     });
 
     return (
-      <div className={toolbarClass}
-           style={this.state.position}
-           ref="toolbarWrapper">
+      <div className={toolbarClass} style={this.state.position}>
         <div style={{position: "absolute", bottom: 0}}>
-          <div className="toolbar__wrapper" ref="toolbar">
+          <div className="toolbar__wrapper" ref={(el) => { this.toolbarEl = el; }}>
             {
               this.state.editingEntity ?
               this.renderEntityInput(this.state.editingEntity) :
               this.renderToolList()
             }
             <p className="toolbar__error-msg">{this.state.error}</p>
-            <span className="toolbar__arrow" ref="arrow"/>
+            <span className="toolbar__arrow" ref={(el) => { this.arrowEl = el; }} />
           </div>
         </div>
       </div>

--- a/src/entity_inputs/LinkInput.js
+++ b/src/entity_inputs/LinkInput.js
@@ -33,7 +33,7 @@ export default class LinkInput extends Component {
 
     if (!url.match(regex)) {
       this.props.setError(__("Invalid Link"));
-      this.refs.textInput.focus();
+      this.textInput.focus();
       return;
     }
 
@@ -75,7 +75,7 @@ export default class LinkInput extends Component {
   }
 
   componentDidMount() {
-    this.refs.textInput.focus();
+    this.textInput.focus();
   }
 
   render() {
@@ -83,7 +83,7 @@ export default class LinkInput extends Component {
     return (
       <div style={{whiteSpace: "nowrap"}}>
         <input
-          ref="textInput"
+          ref={(el) => { this.textInput = el; }}
           type="text"
           className="toolbar__input"
           onChange={this.onLinkChange}

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -169,7 +169,7 @@ describe("MegadraftEditor Component", () => {
   });
 
   it("has the initial text", function() {
-    expect(this.component.refs.editor.textContent).to.have.string("Hello World!");
+    expect(this.component.editorEl.textContent).to.have.string("Hello World!");
   });
 
   it("renders Media component", function() {
@@ -186,7 +186,7 @@ describe("MegadraftEditor Component", () => {
         handlePastedText={handlePastedText}
       />
     );
-    expect(wrapper.ref("draft").props().handlePastedText).to.equal(handlePastedText);
+    expect(wrapper.find(Editor).props().handlePastedText).to.equal(handlePastedText);
   });
 
   it("can't override megadraft props via extra props", function() {
@@ -198,7 +198,7 @@ describe("MegadraftEditor Component", () => {
         blockRendererFn={blockRendererFn}
       />
     );
-    expect(wrapper.ref("draft").props().blockRendererFn).to.not.equal(blockRendererFn);
+    expect(wrapper.find(Editor).props().blockRendererFn).to.not.equal(blockRendererFn);
   });
 
   it("allows blockStyleFn to be overridden", function() {
@@ -210,7 +210,7 @@ describe("MegadraftEditor Component", () => {
         blockStyleFn={blockStyleFn}
       />
     );
-    expect(wrapper.ref("draft").props().blockStyleFn).to.equal(blockStyleFn);
+    expect(wrapper.find(Editor).props().blockStyleFn).to.equal(blockStyleFn);
   });
 
   it("reset blockStyle in new block if resetStyle is true", function() {
@@ -608,8 +608,6 @@ describe("MegadraftEditor Component", () => {
 
   it("passes required props to default toolbar", function() {
     const toolbar = this.wrapper.find(Toolbar);
-    // editor is undefined :-/
-    //expect(toolbar.prop("editor")).to.equal(this.component.refs.editor);
     expect(toolbar.prop("actions")).to.equal(this.component.props.actions);
     expect(toolbar.prop("entityInputs")).to.equal(this.component.entityInputs);
     expect(toolbar.prop("onChange")).to.equal(this.component.onChange);


### PR DESCRIPTION
This updates components to use ref callbacks instead of legacy string refs, see https://facebook.github.io/react/docs/refs-and-the-dom.html#legacy-api-string-refs.