### PR TITLE
Hide toolbar on editor blur

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -42,7 +42,8 @@ export default class MegadraftEditor extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      readOnly: this.props.readOnly || false
+      readOnly: this.props.readOnly || false,
+      hasFocus: false
     };
 
     this.onChange = ::this.onChange;
@@ -51,6 +52,8 @@ export default class MegadraftEditor extends Component {
 
     this.handleKeyCommand = ::this.handleKeyCommand;
     this.handleReturn = ::this.handleReturn;
+    this.handleFocus = ::this.handleFocus;
+    this.handleBlur = ::this.handleBlur;
 
     this.setReadOnly = ::this.setReadOnly;
     this.getReadOnly = ::this.getReadOnly;
@@ -261,6 +264,18 @@ export default class MegadraftEditor extends Component {
     return notFoundPlugin;
   }
 
+  handleFocus() {
+    this.setState({
+      hasFocus: true
+    });
+  }
+
+  handleBlur() {
+    this.setState({
+      hasFocus: false
+    });
+  }
+
   mediaBlockRenderer(block) {
     if (block.getType() !== "atomic") {
       return null;
@@ -314,7 +329,10 @@ export default class MegadraftEditor extends Component {
         <div
           className="megadraft-editor"
           id="megadraft-editor"
-          ref={(el) => { this.editorEl = el; }}>
+          ref={(el) => { this.editorEl = el; }}
+          onBlur={this.handleBlur}
+          onFocus={this.handleFocus}
+        >
           {this.renderSidebar({
             plugins: this.plugins,
             editorState: this.props.editorState,
@@ -338,7 +356,9 @@ export default class MegadraftEditor extends Component {
           />
           {this.renderToolbar({
             editor: this.editorEl,
+            draft: this.refs.draft,
             editorState: this.props.editorState,
+            editorHasFocus: this.state.hasFocus,
             readOnly: this.state.readOnly,
             onChange: this.onChange,
             actions: this.props.actions,

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -14,8 +14,11 @@ import {getSelectionCoords} from "../utils";
 export default class Toolbar extends Component {
   static defaultProps = {
     shouldDisplayToolbarFn() {
-      return !this.editorState.getSelection().isCollapsed();
+      return this.editorHasFocus && !this.editorState.getSelection().isCollapsed();
     },
+  }
+  static propTypes = {
+    editorHasFocus: React.PropTypes.bool
   }
 
   constructor(props) {
@@ -215,10 +218,11 @@ export default class Toolbar extends Component {
   }
 
   cancelEntity() {
-    this.props.editor && this.props.editor.focus();
     this.setState({
       editingEntity: null,
       error: null
+    }, () => {
+      this.props.draft && this.props.draft.focus();
     });
   }
   renderEntityInput(entityType) {
@@ -258,7 +262,7 @@ export default class Toolbar extends Component {
   }
   renderToolList() {
     return (
-      <ul className="toolbar__list" onMouseDown={(x) => {x.preventDefault();}}>
+      <ul className="toolbar__list">
         {this.props.actions.map(this.renderButton)}
       </ul>
     );
@@ -274,7 +278,14 @@ export default class Toolbar extends Component {
     });
 
     return (
-      <div className={toolbarClass} style={this.state.position}>
+      <div
+        className={toolbarClass}
+        style={this.state.position}
+        ref="toolbarWrapper"
+        onMouseDown={(e) => {
+          e.preventDefault();
+        }}
+      >
         <div style={{position: "absolute", bottom: 0}}>
           <div className="toolbar__wrapper" ref={(el) => { this.toolbarEl = el; }}>
             {

--- a/src/components/ToolbarItem.js
+++ b/src/components/ToolbarItem.js
@@ -37,7 +37,9 @@ export default class ToolbarItem extends Component {
     return (
       <li className={className}>
         <button
-          onClick={() => this.toggleAction(this.props)}
+          onClick={() => {
+            this.toggleAction(this.props);
+          }}
           type="button"
           className="toolbar__button">
           <Icon />

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -41,7 +41,8 @@ export default class ToolbarWrapper extends Component {
           actions={this.props.actions}
           readOnly={this.props.readOnly}
           entityInputs={this.props.entityInputs}
-          onChange={this.onChange} />
+          onChange={this.onChange}
+          editorHasFocus={true} />
       </div>
     );
   }


### PR DESCRIPTION
I'd like to propose the following changes to hide the toolbar on editor blur. Presently when the editor loses focus the toolbar can remain visible. This can cause odd UX when using multiple editors, or if there are other form fields on the page, etc.

Keeping the toolbar visible while editing/removing entities was the main challenge, but I was able to do this by moving the `onMouseDown` handler to the toolbar root and setting focus after setting state in `cancelEntity`.