### PR TITLE
Add a change-type to updateData in Media.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "utils-copy": "^1.1.1",
     "webpack": "^3.5.5",
     "webpack-dev-server": "^2.7.1"
-    },
+  },
   "peerDependencies": {
     "react": "^15.6.1",
     "react-dom": "^15.6.1"

--- a/src/components/Media.js
+++ b/src/components/Media.js
@@ -5,7 +5,7 @@
  */
 
 import React, {Component} from "react";
-import {EditorState, SelectionState, Modifier, EditorChangeType} from "draft-js";
+import {EditorState, SelectionState, Modifier} from "draft-js";
 
 import MediaWrapper from "./MediaWrapper";
 
@@ -53,7 +53,7 @@ export default class Media extends Component {
     });
 
     const newContentState = Modifier.mergeBlockData(content, selection, data);
-    const newEditorState = EditorState.push(editorState, newContentState, 'change-block-data');
+    const newEditorState = EditorState.push(editorState, newContentState, "change-block-data");
 
     this.onChange(newEditorState);
   }

--- a/src/components/Media.js
+++ b/src/components/Media.js
@@ -53,7 +53,7 @@ export default class Media extends Component {
     });
 
     const newContentState = Modifier.mergeBlockData(content, selection, data);
-    const newEditorState = EditorState.push(editorState, newContentState);
+    const newEditorState = EditorState.push(editorState, newContentState, 'plugin-update-data');
 
     this.onChange(newEditorState);
   }

--- a/src/components/Media.js
+++ b/src/components/Media.js
@@ -5,7 +5,7 @@
  */
 
 import React, {Component} from "react";
-import {EditorState, SelectionState, Modifier} from "draft-js";
+import {EditorState, SelectionState, Modifier, EditorChangeType} from "draft-js";
 
 import MediaWrapper from "./MediaWrapper";
 
@@ -53,7 +53,7 @@ export default class Media extends Component {
     });
 
     const newContentState = Modifier.mergeBlockData(content, selection, data);
-    const newEditorState = EditorState.push(editorState, newContentState, 'plugin-update-data');
+    const newEditorState = EditorState.push(editorState, newContentState, 'change-block-data');
 
     this.onChange(newEditorState);
   }

--- a/tests/components/Media_test.js
+++ b/tests/components/Media_test.js
@@ -66,14 +66,20 @@ describe("Media Component", function() {
     expect(this.wrapper.length).to.equal(1);
   });
 
-  it("updates data", function() {
+  it("updates data and correct change-type enum", function() {
     let data = this.block.getData();
 
     expect(data.get("display")).to.equal("medium");
 
     this.component.updateData({display: "big"});
 
-    const content = this.blockProps.onChange.args[0][0].toJS().currentContent;
+    const editor = this.blockProps.onChange.args[0][0].toJS();
+    
+    const lastChangeType = editor.lastChangeType;
+
+    expect(lastChangeType).to.equal("change-block-data"); // checking if the last change type is the correct enum
+
+    const content = editor.currentContent;
 
     const nextData = content.blockMap["9vgd"].data;
 

--- a/tests/components/Media_test.js
+++ b/tests/components/Media_test.js
@@ -74,7 +74,7 @@ describe("Media Component", function() {
     this.component.updateData({display: "big"});
 
     const editor = this.blockProps.onChange.args[0][0].toJS();
-    
+
     const lastChangeType = editor.lastChangeType;
 
     expect(lastChangeType).to.equal("change-block-data"); // checking if the last change type is the correct enum


### PR DESCRIPTION
When we update data for plugins, there is no change-type. In order to act on these changes with ```editorState.getLastChangeType()```, I propose to add a type called `plugin-update-data`. We can also make this type configurable and pass it in as a parameter.