### PR TITLE
update backstage-modal to avoid React.PropTypes being used

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Rich Text editor built on top of draft.js",
   "main": "lib/Megadraft.js",
   "dependencies": {
-    "backstage-modal": "^0.2.5",
+    "backstage-modal": "^0.3.2",
     "classnames": "^2.2.5",
     "draft-js": "0.10.1",
     "immutable": "~3.7.4",


### PR DESCRIPTION
`backstage-modal@0.2.5` does not yet use `prop-types` and would block an update to `react@16`.