### PR TITLE
Fix jumping Toolbar and Stack-Overflows when repositioning Toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ make setup
 make run
 ```
 
-Then visit http://localhost:8080/website/#/dev on your browser.
+Then visit http://localhost:8080/#/dev on your browser.
 
 To run local tests:
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -9,7 +9,7 @@ import PropTypes from "prop-types";
 import {EditorState, RichUtils} from "draft-js";
 import classNames from "classnames";
 import ToolbarItem from "./ToolbarItem";
-import {getSelectionCoords} from "../utils";
+import {getSelectionCoords, delayCall} from "../utils";
 
 
 export default class Toolbar extends Component {
@@ -35,6 +35,7 @@ export default class Toolbar extends Component {
     this.removeEntity = ::this.removeEntity;
     this.setError = ::this.setError;
     this.cancelError = ::this.cancelError;
+    this.setBarPosition = delayCall(::this.setBarPosition);
   }
 
   toggleInlineStyle(inlineStyle) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,3 +75,32 @@ export function createTypeStrategy(type) {
     );
   };
 }
+
+/**
+ * Returns a wrapper for the given function which cannot be called
+ * more often than the given interval. Every time the wrapper is called
+ * a timeout gets reset to the interval's number of ms before calling the fn.
+ *
+ * Keep attention to bind the correct context to the provided funtion using bind() or '::'!
+ *
+ * @export
+ * @param {function} fn The function to execute after the given interval.
+ * @param {number} [interval=100] The interval to wait for before calling the wrapped function.
+ * @example
+ * ```
+ * const delayedLog = delayCall(::console.log, 200);
+ * delayedLog('hans');
+ * delayedLog('heiri');
+ * // logs 'heiri' after 200ms, 'hans' won't be logged at all.
+ * ```
+ * @returns {void}
+ */
+export function delayCall(fn, interval = 100) {
+  let timeout;
+  return function (...args) {
+    if (timeout) {
+      window.clearTimeout(timeout);
+    }
+    timeout = window.setTimeout(() => fn.apply(window, args), interval);
+  };
+}


### PR DESCRIPTION
This PR should solve the issues described at https://github.com/globocom/megadraft/issues/157 and https://github.com/globocom/megadraft/issues/161:

In some versions of Chrome and IE, when selecting an item in the toolbar, such as creating an inline link, the browser freezes and finally throws a stack-overflow exception.

**Steps to reproduce the error** , as described by @CameronAckermanSEL at #157:
1. Highlight text on megadraft live demo
2. Click the link button on the inline toolbar
3. Observe that site hangs, and eventually error appears in devtools console.

I am not sure if this issue is already solved by another PR, I just found the two issues described above still opened.