### PR TITLE
Make blockRendererFn customizable

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -350,7 +350,7 @@ export default class MegadraftEditor extends Component {
             ref={(el) => { this.draftEl = el; }}
             readOnly={this.state.readOnly}
             plugins={this.plugins}
-            blockRendererFn={this.mediaBlockRenderer}
+            blockRendererFn={this.props.blockRendererFn || this.mediaBlockRenderer}
             blockStyleFn={this.props.blockStyleFn || this.blockStyleFn}
             onTab={this.onTab}
             handleKeyCommand={this.handleKeyCommand}

--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -37,6 +37,7 @@ const NO_RESET_STYLE_DEFAULT = ["ordered-list-item", "unordered-list-item"];
 export default class MegadraftEditor extends Component {
   static defaultProps = {
     actions: DEFAULT_ACTIONS,
+    blockRendererFn: () => {},
   }
 
   constructor(props) {
@@ -281,6 +282,12 @@ export default class MegadraftEditor extends Component {
   }
 
   mediaBlockRenderer(block) {
+
+    const handled = this.props.blockRendererFn(block);
+    if (handled) {
+      return handled;
+    }
+
     if (block.getType() !== "atomic") {
       return null;
     }
@@ -350,7 +357,7 @@ export default class MegadraftEditor extends Component {
             ref={(el) => { this.draftEl = el; }}
             readOnly={this.state.readOnly}
             plugins={this.plugins}
-            blockRendererFn={this.props.blockRendererFn || this.mediaBlockRenderer}
+            blockRendererFn={this.mediaBlockRenderer}
             blockStyleFn={this.props.blockStyleFn || this.blockStyleFn}
             onTab={this.onTab}
             handleKeyCommand={this.handleKeyCommand}

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -197,6 +197,24 @@ describe("MegadraftEditor Component", () => {
     expect(wrapper.find(Editor).props().blockRendererFn).not.toEqual(blockRendererFn);
   });
 
+  it("allows blockRendererFn to be augmented with mediaBlockRenderer", () => {
+    const contentBlock = { getType: () => "atomic" }
+    const blockRendererFn = contentBlock => { 
+      const type = contentBlock.getType();
+      if (type === 'atomic') {  
+        return true;
+      }
+    };
+    const wrapper = mount(
+      <MegadraftEditor
+        editorState={testContext.editorState}
+        onChange={testContext.onChange}
+        blockRendererFn={blockRendererFn}
+      />
+    );
+    expect(wrapper.find(Editor).props().blockRendererFn(contentBlock)).toEqual(true);
+  });
+
   it("allows blockStyleFn to be overridden", () => {
     const blockStyleFn = (text) => { return text; };
     const wrapper = mount(

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -198,10 +198,12 @@ describe("MegadraftEditor Component", () => {
   });
 
   it("allows blockRendererFn to be augmented with mediaBlockRenderer", () => {
-    const contentBlock = { getType: () => "atomic" }
-    const blockRendererFn = contentBlock => { 
+    const contentBlock = {
+      getType: () => "atomic"
+    };
+    const blockRendererFn = contentBlock => {
       const type = contentBlock.getType();
-      if (type === 'atomic') {  
+      if (type === "atomic") {
         return true;
       }
     };

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -186,6 +186,18 @@ describe("MegadraftEditor Component", () => {
   });
 
   it("can't override megadraft props via extra props", () => {
+    const handleKeyCommand = (text) => { return text; };
+    const wrapper = mount(
+      <MegadraftEditor
+        editorState={testContext.editorState}
+        onChange={testContext.onChange}
+        handleKeyCommand={handleKeyCommand}
+      />
+    );
+    expect(wrapper.find(Editor).props().handleKeyCommand).not.toEqual(handleKeyCommand);
+  });
+
+  it("allows blockRendererFn to be overridden", () => {
     const blockRendererFn = (text) => { return text; };
     const wrapper = mount(
       <MegadraftEditor
@@ -194,7 +206,7 @@ describe("MegadraftEditor Component", () => {
         blockRendererFn={blockRendererFn}
       />
     );
-    expect(wrapper.find(Editor).props().blockRendererFn).not.toEqual(blockRendererFn);
+    expect(wrapper.find(Editor).props().blockRendererFn).toEqual(blockRendererFn);
   });
 
   it("allows blockStyleFn to be overridden", () => {

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -186,18 +186,6 @@ describe("MegadraftEditor Component", () => {
   });
 
   it("can't override megadraft props via extra props", () => {
-    const handleKeyCommand = (text) => { return text; };
-    const wrapper = mount(
-      <MegadraftEditor
-        editorState={testContext.editorState}
-        onChange={testContext.onChange}
-        handleKeyCommand={handleKeyCommand}
-      />
-    );
-    expect(wrapper.find(Editor).props().handleKeyCommand).not.toEqual(handleKeyCommand);
-  });
-
-  it("allows blockRendererFn to be overridden", () => {
     const blockRendererFn = (text) => { return text; };
     const wrapper = mount(
       <MegadraftEditor
@@ -206,7 +194,7 @@ describe("MegadraftEditor Component", () => {
         blockRendererFn={blockRendererFn}
       />
     );
-    expect(wrapper.find(Editor).props().blockRendererFn).toEqual(blockRendererFn);
+    expect(wrapper.find(Editor).props().blockRendererFn).not.toEqual(blockRendererFn);
   });
 
   it("allows blockStyleFn to be overridden", () => {


### PR DESCRIPTION
Hi 👋, Thanks for the awesome work on the editor. 

This PR does the following:- 

1. Merges blockRendererFn with internal mediaBlockRenderer

2. Add test case for customizable blockRendererFn

Please let me know if any changes are needed 🙏