### PR TITLE
Don't prevent tab events

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -117,7 +117,6 @@ export default class MegadraftEditor extends Component {
   }
 
   onTab(event) {
-    event.preventDefault();
     if (this.props.onTab) {
       this.props.onTab(event);
     }


### PR DESCRIPTION
Allow users to tab outside the megadraft component. Discussed in #172 