### PR TITLE
Prevent exception in Toolbar with readOnly true

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -15,7 +15,11 @@ import {getSelectionCoords} from "../utils";
 export default class Toolbar extends Component {
   static defaultProps = {
     shouldDisplayToolbarFn() {
-      return this.editorHasFocus && !this.editorState.getSelection().isCollapsed();
+      return (
+        this.editorHasFocus &&
+        !this.editorState.getSelection().isCollapsed() &&
+        !this.readOnly
+      );
     },
   }
   static propTypes = {

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -252,6 +252,19 @@ describe("Toolbar Component", () => {
       expect(toolbarWrapperNode.style.left).toEqual(minOffsetRight + "px");
     });
 
+    it("should not throw an exception if readOnly = true while there is an exception", () => {
+      replaceSelection(
+        {
+          focusOffset: 0,
+          anchorOffset: 5
+        },
+        testContext.wrapper
+      );
+
+      testContext.wrapper.update();
+      testContext.wrapper.setProps({readOnly: true});
+    });
+
     describe("entity inputs", () => {
       beforeEach(() => {
         testContext.linkButton = () =>


### PR DESCRIPTION
In our app, we have a plugin that has an input inside of it. I'm not super clear why this is happening, but when focusing into that input field, the MegaDraftEditor turns to readOnly and passes `readOnly={true}` to Toolbar.

Since Toolbar doesn't render anything if `readOnly` is `true`, the `this.toolbarEl` ref is `null` and we get this stacktrace:
```
TypeError: Cannot read property 'offsetHeight' of null

      64 |   const rangeWidth = rangeBounds.right - rangeBounds.left;
      65 |   const arrowStyle = {};
    > 66 | 
      67 |   let offsetLeft = (rangeBounds.left - editorBounds.left) + (rangeWidth / 2);
      68 |   arrowStyle.left = "50%";
      69 |   if (offsetLeft - toolbarWidth / 2 + editorBounds.left < minOffsetLeft) {
      
      at getSelectionCoords (src/utils.js:66:31)
      at Toolbar.setBarPosition (src/components/Toolbar.js:158:59)
      at Toolbar.handleSetToolbar (src/components/Toolbar.js:180:21)
      at Toolbar.componentDidUpdate (src/components/Toolbar.js:213:14)
```

(The error message is a bit off because of transpilation, it's actually on line 53)

Anyway, since we're not displaying the toolbar in `readOnly` mode, we don't need to update its positioning. So I made this change and it seems to fix the exception.

Thanks!