### PR TITLE
LinkInput: Fix placeholder color when url is invalid

### DIFF
--- a/src/styles/megadraft.scss
+++ b/src/styles/megadraft.scss
@@ -4,6 +4,7 @@
  * License: MIT
  */
 
+@import "mixins.scss";
 @import "modal.scss";
 
 .megadraft-editor {

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018, Globo.com (https://github.com/globocom)
+ *
+ * License: MIT
+ */
+
+@mixin placeholder {
+    ::-webkit-input-placeholder {@content}
+    :-moz-placeholder           {@content}
+    ::-moz-placeholder          {@content}
+    :-ms-input-placeholder      {@content}
+}

--- a/src/styles/toolbar.scss
+++ b/src/styles/toolbar.scss
@@ -41,6 +41,9 @@
       .toolbar__button {
         color: #FFF;
       }
+      @include placeholder {
+        color: #FFF;
+      }
     }
 
     &__wrapper {


### PR DESCRIPTION
When the url was empty the placeholder color was grey on red background, it should be white to improve readability.