### PR TITLE
Pass onChange to custom toolbar actions

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -67,7 +67,7 @@ export default class Toolbar extends Component {
     switch (item.type) {
       case "custom": {
         key = "custom-" + position;
-        toggle = () => item.action(this.props.editorState);
+        toggle = () => item.action(this.props.editorState, this.props.onChange);
         break;
       }
       case "inline": {


### PR DESCRIPTION
Allows for much more robust (and modular) changes from custom toolbar actions. 

Example: A simple "Smile" action:

```
import { EditorState, Modifier } from 'draft-js';
import actions from 'megadraft/lib/actions/default';

export default actions.concat([
  {
    type: 'custom',
    icon: props => (
      <Smile
        {...props}
        width="24"
        height="18"
        fill="currentColor"
        fillRule="evenodd"
      />
    ),
    action(editorState, onChange) {
      const contentState = Modifier.replaceText(
        editorState.getCurrentContent(),
        editorState.getSelection(),
        '😀',
        editorState.getCurrentInlineStyle()
      );

      onChange(EditorState.push(editorState, contentState, 'insert-characters'));
    }
  }
]);
```