### PR TITLE
Add optional prop "id" to MegadraftEditor

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -387,7 +387,7 @@ export default class MegadraftEditor extends Component {
       <div className="megadraft">
         <div
           className="megadraft-editor"
-          id="megadraft-editor"
+          id={this.props.id || "megadraft-editor"}
           ref={el => {
             this.editorEl = el;
           }}

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -221,6 +221,28 @@ describe("MegadraftEditor Component", () => {
     );
   });
 
+  it("provides a default id to the wrapping div", () => {
+    const wrapper = mount(
+      <MegadraftEditor
+        editorState={testContext.editorState}
+        onChange={testContext.onChange}
+      />
+    );
+    expect(wrapper.find(".megadraft-editor").props().id).toBeDefined();
+  });
+
+  it("allows the wrapping div id to be overridden", () => {
+    const id = "custom-id";
+    const wrapper = mount(
+      <MegadraftEditor
+        editorState={testContext.editorState}
+        onChange={testContext.onChange}
+        id={id}
+      />
+    );
+    expect(wrapper.find(".megadraft-editor").props().id).toEqual(id);
+  });
+
   it("allows blockRendererFn to be augmented with mediaBlockRenderer", () => {
     const contentBlock = {
       getType: () => "atomic"


### PR DESCRIPTION
I have some scenarios where I need multiple `MegadraftEditor` at once in a page (like several cards with a `MegadraftEditor` on each one). In that case, I would have several elements with the same ID on the same tree, which goes against [the spec](https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute):

> When specified on HTML elements, the **id attribute value must be unique amongst all the IDs in the element's tree** and must contain at least one character. The value must not contain any ASCII whitespace.

So I need to be able to customize the ID, while leaving untouched the existing default.
