### PR TITLE
Add optional custom input to toolbar action items

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -61,12 +61,15 @@ export default class Toolbar extends Component {
     let current = null;
     let toggle = null;
     let active = null;
+    let input = null;
     let key = item.label;
 
     switch (item.type) {
       case "custom": {
         key = "custom-" + position;
         toggle = () => item.action(this.props.editorState, this.props.onChange);
+        input = item.input &&
+          () => item.input(this.props.editorState, this.props.onChange)
         break;
       }
       case "inline": {
@@ -99,7 +102,13 @@ export default class Toolbar extends Component {
     }
 
     return (
-      <ToolbarItem key={key} active={active} toggle={toggle} item={item} />
+      <ToolbarItem
+        key={key}
+        active={active}
+        toggle={toggle}
+        item={item}
+        input={input}
+      />
     );
   }
 

--- a/src/components/ToolbarItem.js
+++ b/src/components/ToolbarItem.js
@@ -22,6 +22,7 @@ export default class ToolbarItem extends Component {
 
   render() {
     const Icon = this.props.item.icon;
+    const Input = this.props.item.input;
 
     if (this.props.item.type == "separator") {
       return <Separator />;
@@ -33,15 +34,19 @@ export default class ToolbarItem extends Component {
 
     return (
       <li className={className}>
-        <button
-          onClick={() => {
-            this.toggleAction(this.props);
-          }}
-          type="button"
-          className="toolbar__button"
-        >
-          <Icon />
-        </button>
+        {Input ? (
+          <Input />
+        ) : (
+          <button
+            onClick={() => {
+              this.toggleAction(this.props);
+            }}
+            type="button"
+            className="toolbar__button"
+          >
+            <Icon />
+          </button>
+        )}
       </li>
     );
   }


### PR DESCRIPTION
referencing #227 

this should allow someone to add an input function to their custom actions that will allow an input such as a select dropdown to be present in the list of toolbar items rather than as an entity input.