### PR TITLE
Give shouldDisplayTollbarFn more control over toolbar rendering

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -291,7 +291,7 @@ export default class Toolbar extends Component {
     );
   }
   render() {
-    if (this.props.readOnly) {
+    if (this.props.readOnly && !this.props.shouldDisplayToolbarFn) {
       return null;
     }
 


### PR DESCRIPTION
Currently the Toolbar is hidden if `readOnly` is `true`.  Also the `shouldDisplayTollbarFn` allows control over rendering the Toolbar but only in edit mode.

We want to be able to have complete control over the rendering of the toolbar with passing in the optional `shouldDisplayToolbarFn`. To do this we should prevent rendering the toolbar if `readOnly=true && !shouldDisplayToolbarFn`