### PR TITLE
give shouldDisplayToolbarFn more control to render Toolbar

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -291,7 +291,10 @@ export default class Toolbar extends Component {
     );
   }
   render() {
-    if (this.props.readOnly) {
+    if (
+      this.props.readOnly &&
+      !this.props.shouldDisplayToolbarFn(this.props, this.state)
+    ) {
       return null;
     }
 

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -40,6 +40,7 @@ export default class ToolbarWrapper extends Component {
           entityInputs={this.props.entityInputs}
           onChange={this.onChange}
           editorHasFocus={true}
+          shouldDisplayToolbarFn={this.props.shouldDisplayToolbarFn}
         />
       </div>
     );
@@ -140,12 +141,26 @@ describe("Toolbar Component", () => {
       expect(items).toHaveLength(1);
     });
 
-    it("renders as null when readOnly is set", () => {
+    it("renders when readOnly is set but shouldDisplayToolbarFn returns true", () => {
       const wrapper = mount(
         <ToolbarWrapper
           readOnly
           editorState={testContext.editorState}
           actions={testContext.actions}
+          shouldDisplayToolbarFn={() => true}
+        />
+      );
+      const toolbar = wrapper.find(Toolbar);
+      expect(toolbar.html()).not.toBeNull();
+    });
+
+    it("renders as null when readOnly is set and shouldDisplayToolbarFn returns false", () => {
+      const wrapper = mount(
+        <ToolbarWrapper
+          readOnly
+          editorState={testContext.editorState}
+          actions={testContext.actions}
+          shouldDisplayToolbarFn={() => false}
         />
       );
       const toolbar = wrapper.find(Toolbar);


### PR DESCRIPTION
Currently there is a stop to not render the toolbar if `readOnly=true` which could happen sometimes in edit mode for the editor, example in Media blocks. 

I was experiencing this when I was trying to edit a custom plugin, and even though I was passing `shouldDisplayToolbarFn = () => true` the toolbar would still disappear because `readOnly` was being toggled to `true`.

This PR is meant to allow developers more control over the rendering of the Toolbar if they pass in the `shouldDisplayToolbarFn`.