### PR TITLE
Apply block types to multiple blocks

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -93,7 +93,7 @@ export default class Toolbar extends Component {
         const { entity = "LINK" } = item;
         key = "entity-" + entity;
         toggle = () => this.toggleEntity(entity);
-        active = this.hasEntity(entity);
+        active = this.hasEntity(entity) || this.hasStyle(item.style);
         break;
       }
     }
@@ -160,13 +160,6 @@ export default class Toolbar extends Component {
 
     if (currentContentState === newContentState) {
       this.shouldUpdatePos = true;
-      this.setState({
-        show: true
-      });
-    } else {
-      this.setState({
-        show: false
-      });
     }
   }
 
@@ -193,6 +186,12 @@ export default class Toolbar extends Component {
       return contentState.getEntity(entityKey);
     }
     return null;
+  }
+
+  hasStyle(style) {
+    const current = this.props.editorState.getCurrentInlineStyle();
+    const withStyle = current.filter((val, key) => key.startsWith(style));
+    return withStyle.size > 0;
   }
 
   hasEntity(entityType) {
@@ -291,7 +290,10 @@ export default class Toolbar extends Component {
     );
   }
   render() {
-    if (this.props.readOnly) {
+    if (
+      this.props.readOnly &&
+      !this.props.shouldDisplayToolbarFn(this.props, this.state)
+    ) {
       return null;
     }
 
@@ -305,15 +307,17 @@ export default class Toolbar extends Component {
         className={toolbarClass}
         style={this.state.position}
         ref="toolbarWrapper"
-        onMouseDown={e => {
-          e.preventDefault();
-        }}
       >
         <div style={{ position: "absolute", bottom: 0 }}>
           <div
             className="toolbar__wrapper"
             ref={el => {
               this.toolbarEl = el;
+            }}
+            onMouseDown={e => {
+              if (e.target.localName !== "input") {
+                e.preventDefault();
+              }
             }}
           >
             {this.state.editingEntity

--- a/src/utils.js
+++ b/src/utils.js
@@ -137,3 +137,17 @@ export function delayCall(fn, interval = 100) {
     timeout = window.setTimeout(() => fn.apply(window, args), interval);
   };
 }
+
+// credit: https://github.com/jpuri/draftjs-utils/blob/eca1508cf74c8b05ce7d3ab39ab28247cb254d5f/js/block.js#L13
+export function getSelectedBlocksMap(editorState) {
+  const selectionState = editorState.getSelection();
+  const contentState = editorState.getCurrentContent();
+  const startKey = selectionState.getStartKey();
+  const endKey = selectionState.getEndKey();
+  const blockMap = contentState.getBlockMap();
+  return blockMap
+    .toSeq()
+    .skipUntil((_, k) => k === startKey)
+    .takeUntil((_, k) => k === endKey)
+    .concat([[endKey, blockMap.get(endKey)]]);
+}

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -40,6 +40,7 @@ export default class ToolbarWrapper extends Component {
           entityInputs={this.props.entityInputs}
           onChange={this.onChange}
           editorHasFocus={true}
+          shouldDisplayToolbarFn={this.props.shouldDisplayToolbarFn}
         />
       </div>
     );
@@ -140,12 +141,26 @@ describe("Toolbar Component", () => {
       expect(items).toHaveLength(1);
     });
 
-    it("renders as null when readOnly is set", () => {
+    it("renders when readOnly is set but shouldDisplayToolbarFn returns true", () => {
       const wrapper = mount(
         <ToolbarWrapper
           readOnly
           editorState={testContext.editorState}
           actions={testContext.actions}
+          shouldDisplayToolbarFn={() => true}
+        />
+      );
+      const toolbar = wrapper.find(Toolbar);
+      expect(toolbar.html()).not.toBeNull();
+    });
+
+     it("renders as null when readOnly is set and shouldDisplayToolbarFn returns false", () => {
+      const wrapper = mount(
+        <ToolbarWrapper
+          readOnly
+          editorState={testContext.editorState}
+          actions={testContext.actions}
+          shouldDisplayToolbarFn={() => false}
         />
       );
       const toolbar = wrapper.find(Toolbar);


### PR DESCRIPTION
In the case where there is a selection state that has a range of multiple blocks that surround a media/atomic block, using Draft.JS `RichUtils.toggleBlockType` will just return the current `editorState`. This is shown here in the Draft.JS source: https://github.com/facebook/draft-js/blob/c21a9f7f09fa737f27875dc5ca8264a0b1dc86c2/src/model/modifier/RichTextEditorUtil.js#L254

To get around this I changed the `toggleBlockType` method in the toolbar to get the Map of blocks in the selection range and update each block's type individually and skipping blocks that have `type=atomic`.