### PR TITLE
Bug Fixes and Feature Requests

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -292,7 +292,10 @@ export default class Toolbar extends Component {
     );
   }
   render() {
-    if (this.props.readOnly) {
+    if (
+      this.props.readOnly ||
+      !this.props.shouldDisplayToolbarFn(this.props, this.state)
+    ) {
       return null;
     }
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -161,13 +161,6 @@ export default class Toolbar extends Component {
 
     if (currentContentState === newContentState) {
       this.shouldUpdatePos = true;
-      this.setState({
-        show: true
-      });
-    } else {
-      this.setState({
-        show: false
-      });
     }
   }
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -306,15 +306,17 @@ export default class Toolbar extends Component {
         className={toolbarClass}
         style={this.state.position}
         ref="toolbarWrapper"
-        onMouseDown={e => {
-          e.preventDefault();
-        }}
       >
         <div style={{ position: "absolute", bottom: 0 }}>
           <div
             className="toolbar__wrapper"
             ref={el => {
               this.toolbarEl = el;
+            }}
+            onMouseDown={e => {
+              if (e.target.localName !== "input") {
+                e.preventDefault();
+              }
             }}
           >
             {this.state.editingEntity

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -40,6 +40,7 @@ export default class ToolbarWrapper extends Component {
           entityInputs={this.props.entityInputs}
           onChange={this.onChange}
           editorHasFocus={true}
+          shouldDisplayToolbarFn={this.props.shouldDisplayToolbarFn}
         />
       </div>
     );
@@ -123,6 +124,7 @@ describe("Toolbar Component", () => {
         editorState={testContext.editorState}
         actions={testContext.actions}
         entityInputs={testContext.entityInputs}
+        shouldDisplayToolbarFn={() => true}
       />
     );
   });
@@ -142,12 +144,25 @@ describe("Toolbar Component", () => {
       expect(items).toHaveLength(1);
     });
 
-    it("renders as null when readOnly is set", () => {
+    it("renders null when readOnly is set and shouldDisplayToolbarFn returns true", () => {
       const wrapper = mount(
         <ToolbarWrapper
           readOnly
           editorState={testContext.editorState}
           actions={testContext.actions}
+          shouldDisplayToolbarFn={() => true}
+        />
+      );
+      const toolbar = wrapper.find(Toolbar);
+      expect(toolbar.html()).toBeNull();
+    });
+
+    it("renders as null when readOnly is not set and shouldDisplayToolbarFn returns false", () => {
+      const wrapper = mount(
+        <ToolbarWrapper
+          editorState={testContext.editorState}
+          actions={testContext.actions}
+          shouldDisplayToolbarFn={() => false}
         />
       );
       const toolbar = wrapper.find(Toolbar);
@@ -218,50 +233,74 @@ describe("Toolbar Component", () => {
       });
     });
 
-    it("starts hidden", () => {
-      const toolbarWrapper = testContext.wrapper.find(".toolbar");
-      expect(toolbarWrapper.hasClass("toolbar--open")).toBeFalsy();
+    it("starts hidden when using default shouldDisplayToolbarFn", () => {
+      const wrapper = mount(
+        <ToolbarWrapper
+          editorState={testContext.editorState}
+          actions={testContext.actions}
+          entityInputs={testContext.entityInputs}
+        />
+      );
+      const toolbar = wrapper.find(Toolbar);
+      expect(toolbar.html()).toBeNull();
     });
 
-    it("shows after selection", () => {
+    it("shows after selection when using default shouldDisplayToolbarFn", () => {
+      const wrapper = mount(
+        <ToolbarWrapper
+          editorState={testContext.editorState}
+          actions={testContext.actions}
+          entityInputs={testContext.entityInputs}
+        />
+      );
+
       replaceSelection(
         {
           focusOffset: 0,
           anchorOffset: 5
         },
-        testContext.wrapper
+        wrapper
       );
 
-      testContext.clock.advanceTimersByTime(32);
-      testContext.wrapper.update();
+      wrapper.update();
 
-      const toolbarWrapper = testContext.wrapper.find(".toolbar");
+      const toolbar = wrapper.find(Toolbar);
+      const toolbarWrapper = wrapper.find(".toolbar");
+      expect(toolbar.html()).not.toBeNull();
       expect(toolbarWrapper.hasClass("toolbar--open")).toBeTruthy();
     });
 
-    it("should hide after deselection", () => {
+    it("should hide after deselection when using default shouldDisplayToolbarFn", () => {
+      const wrapper = mount(
+        <ToolbarWrapper
+          editorState={testContext.editorState}
+          actions={testContext.actions}
+          entityInputs={testContext.entityInputs}
+        />
+      );
+
       replaceSelection(
         {
           focusOffset: 0,
           anchorOffset: 5
         },
-        testContext.wrapper
+        wrapper
       );
 
-      testContext.wrapper.update();
+      wrapper.update();
 
       replaceSelection(
         {
           focusOffset: 0,
           anchorOffset: 0
         },
-        testContext.wrapper
+        wrapper
       );
 
-      testContext.wrapper.update();
+      wrapper.update();
 
-      const toolbarWrapper = testContext.wrapper.find(".toolbar");
-      expect(toolbarWrapper.hasClass("toolbar--open")).toBeFalsy();
+      const toolbar = wrapper.find(Toolbar);
+      expect(toolbar.html()).toBeNull();
     });
 
     it("should center toolbar above the selection", () => {


### PR DESCRIPTION
Megadraft team,

Thanks for your project, it has really helped our team get off the ground with Draft.JS

With that said we had a few features and bugs that we would like to share with the main project.

1. preventing default on the toolbar onMouseDown was preventing the cursor from selecting text in text entity inputs (ex. LinkInput), so I put  a condition to prevent default only when it is not a text input.

2. A new feature that is nice is to have an entity toolbar item to have an active state, so I added a hasStyle method to the toolbar to check for entity active state.

3. Currently `shouldDisplayToolbarFn` is an optional prop. But if I want the toolbar to be sticky or always show, this function is limited because of the `readOnly` check in toolbar render. I added the function as another condition in the toolbar render to extend its ability to control the toolbar display.

4. We were wanting to display the changes to the editor immediately from an entity input (such as a color input). When onChange was being called it would close the toolbar. After removing the show/hide stateChanges in `componentWillReceiveProps` this allowed the editor to stay open when onChange is called but did not remove the improvements done in this PR: #195 

5. Since the beginning, Draft.JS `RichUtils.toggleBlockType` avoids applying block type changes to the editor state when the selection range has a media/atomic blockType.  The desired functionality we were looking for was that the block type would be applied to all the non atomic blocks. I refactored the toggleBlockType method in the Toolbar to individually change the blockTypes of each block and skip atomic blocks.