### PR TITLE
Fixing website menu "Documentation" position

### DIFF
--- a/website/components/menubar.js
+++ b/website/components/menubar.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useState, useRef } from "react";
 import { Sticky } from "react-sticky";
 import Scroll from "react-scroll";
 import { Link } from "react-router-dom";
@@ -13,149 +13,139 @@ import Button from "@material-ui/core/Button";
 
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
+const scrollEvents = Scroll.Events;
 
-class MenuBar extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      open: false,
-      content: true
-    };
-  }
+const MenuBar = props => {
+  const { background = common.white, showLeft, children } = props;
+  const [showMenuDropdown, setShowMenuDropdown] = useState(false);
+  const documentationMenu = useRef(null);
 
-  handleTouchTap = event => {
+  const handleTouchTap = event => {
     // This prevents ghost click.
     event.preventDefault();
+
     scroller.scrollTo("appbar", { duration: 300, smooth: true });
-
-    this.setState({
-      open: true,
-      anchorEl: event.currentTarget
+    scrollEvents.scrollEvent.register("end", () => {
+      setShowMenuDropdown(true);
     });
   };
 
-  handleRequestClose = () => {
-    this.setState({
-      open: false
-    });
+  const handleRequestClose = () => {
+    setShowMenuDropdown(false);
   };
 
-  render() {
-    const background = this.props.background || common.white;
-    const showLeft = this.props.showLeft;
-
-    return (
-      <Element name="appbar">
-        <Sticky>
-          {({ style }) => (
-            <Toolbar
-              style={{
-                ...style,
-                background,
-                zIndex: 1100,
-                border: "1px solid rgba(0, 0, 0, 0.1)"
-              }}
-            >
-              <Grid container>
-                {showLeft ? (
-                  <Grid item xs={6}>
-                    <Grid container direction="row" justify="space-evenly">
-                      <Button component={Link} to="/">
-                        Home
-                      </Button>
-                      <Button
-                        onClick={this.handleTouchTap}
-                        style={{ boxShadow: common.white }}
-                      >
-                        Documentation
-                      </Button>
-                      <Menu
-                        id="simple-menu"
-                        anchorEl={this.state.anchorEl}
-                        open={Boolean(this.state.open)}
-                        onClose={this.handleRequestClose}
-                      >
-                        <MenuItem
-                          onClick={this.handleRequestClose}
-                          component={Link}
-                          to="/docs/overview"
-                        >
-                          Overview & Usage
-                        </MenuItem>
-                        <MenuItem
-                          component={Link}
-                          onClick={this.handleRequestClose}
-                          to="/docs/customization"
-                        >
-                          Customization
-                        </MenuItem>
-                        <MenuItem
-                          component={Link}
-                          onClick={this.handleRequestClose}
-                          to="/docs/plugins"
-                        >
-                          Plugins
-                        </MenuItem>
-                        <MenuItem
-                          component={Link}
-                          onClick={this.handleRequestClose}
-                          to="/docs/custom-entities"
-                        >
-                          Custom Entities
-                        </MenuItem>
-                        <MenuItem
-                          component={Link}
-                          onClick={this.handleRequestClose}
-                          to="/docs/saving-loading"
-                        >
-                          Saving & Loading
-                        </MenuItem>
-                        <Divider />
-                        <MenuItem
-                          component={"a"}
-                          onClick={this.handleRequestClose}
-                          href="http://draftjs.org"
-                          target="_blank"
-                        >
-                          Draft.js
-                        </MenuItem>
-                        <MenuItem
-                          component={"a"}
-                          onClick={this.handleRequestClose}
-                          href="https://facebook.github.io/react/"
-                          target="_blank"
-                        >
-                          React
-                        </MenuItem>
-                      </Menu>
-                      <Button
-                        href="https://draftjs.slack.com/messages/megadraft/"
-                        target="_blank"
-                      >
-                        Slack channel
-                      </Button>
-                      <Button
-                        href="https://github.com/globocom/megadraft"
-                        target="_blank"
-                      >
-                        Repository
-                      </Button>
-                    </Grid>
-                  </Grid>
-                ) : (
-                  <Grid item xs={6} />
-                )}
-
+  return (
+    <Element name="appbar">
+      <Sticky>
+        {({ style }) => (
+          <Toolbar
+            style={{
+              ...style,
+              background,
+              zIndex: 1100,
+              border: "1px solid rgba(0, 0, 0, 0.1)"
+            }}
+          >
+            <Grid container>
+              {showLeft ? (
                 <Grid item xs={6}>
-                  {this.props.children}
+                  <Grid container direction="row" justify="space-evenly">
+                    <Button component={Link} to="/">
+                      Home
+                    </Button>
+                    <Button
+                      ref={documentationMenu}
+                      onClick={handleTouchTap}
+                      style={{ boxShadow: common.white }}
+                    >
+                      Documentation
+                    </Button>
+                    <Menu
+                      id="simple-menu"
+                      anchorEl={documentationMenu.current}
+                      open={Boolean(showMenuDropdown)}
+                      onClose={handleRequestClose}
+                    >
+                      <MenuItem
+                        onClick={handleRequestClose}
+                        component={Link}
+                        to="/docs/overview"
+                      >
+                        Overview & Usage
+                      </MenuItem>
+                      <MenuItem
+                        component={Link}
+                        onClick={handleRequestClose}
+                        to="/docs/customization"
+                      >
+                        Customization
+                      </MenuItem>
+                      <MenuItem
+                        component={Link}
+                        onClick={handleRequestClose}
+                        to="/docs/plugins"
+                      >
+                        Plugins
+                      </MenuItem>
+                      <MenuItem
+                        component={Link}
+                        onClick={handleRequestClose}
+                        to="/docs/custom-entities"
+                      >
+                        Custom Entities
+                      </MenuItem>
+                      <MenuItem
+                        component={Link}
+                        onClick={handleRequestClose}
+                        to="/docs/saving-loading"
+                      >
+                        Saving & Loading
+                      </MenuItem>
+                      <Divider />
+                      <MenuItem
+                        component={"a"}
+                        onClick={handleRequestClose}
+                        href="http://draftjs.org"
+                        target="_blank"
+                      >
+                        Draft.js
+                      </MenuItem>
+                      <MenuItem
+                        component={"a"}
+                        onClick={handleRequestClose}
+                        href="https://facebook.github.io/react/"
+                        target="_blank"
+                      >
+                        React
+                      </MenuItem>
+                    </Menu>
+                    <Button
+                      href="https://draftjs.slack.com/messages/megadraft/"
+                      target="_blank"
+                    >
+                      Slack channel
+                    </Button>
+                    <Button
+                      href="https://github.com/globocom/megadraft"
+                      target="_blank"
+                    >
+                      Repository
+                    </Button>
+                  </Grid>
                 </Grid>
+              ) : (
+                <Grid item xs={6} />
+              )}
+
+              <Grid item xs={6}>
+                {children}
               </Grid>
-            </Toolbar>
-          )}
-        </Sticky>
-      </Element>
-    );
-  }
-}
+            </Grid>
+          </Toolbar>
+        )}
+      </Sticky>
+    </Element>
+  );
+};
 
 export default MenuBar;

--- a/website/components/menubar.js
+++ b/website/components/menubar.js
@@ -13,7 +13,6 @@ import Button from "@material-ui/core/Button";
 
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
-const scrollEvents = Scroll.Events;
 
 const MenuBar = props => {
   const { background = common.white, showLeft, children } = props;
@@ -25,14 +24,10 @@ const MenuBar = props => {
     event.preventDefault();
 
     scroller.scrollTo("appbar", { duration: 300, smooth: true });
-    scrollEvents.scrollEvent.register("end", () => {
-      setShowMenuDropdown(true);
-    });
+    setTimeout(() => setShowMenuDropdown(true), 300);
   };
 
-  const handleRequestClose = () => {
-    setShowMenuDropdown(false);
-  };
+  const handleRequestClose = () => setShowMenuDropdown(false);
 
   return (
     <Element name="appbar">


### PR DESCRIPTION
## Context
When you are inside the website, if you click on the Documentation menu, the scroller will create a weird behavior showing the Left Dropdown at nowhere. 

## Steps to Reproduce the Bug

- Desktop Google Chrome Version 77.0.3865.90
- Open website
- Scroll half of the current viewport, enough to see the documentation menu
- Click on documentation menu

## Developed

- Add a listener to the **end**  event of the scrolling
- Only render the documentation menu after the scrolling animation ends
- Refactoring menubar with react hooks

close #248 