### PR TITLE
Bad rendering when attempting to remove a blockquote - Iss187

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -322,6 +322,34 @@ export default class MegadraftEditor extends Component {
     }, 200);
   }
 
+  handleClassEditor(identifier) {
+    let classEditor = identifier;
+    let contentState = this.props.editorState.getCurrentContent();
+    // If the user changes block type before entering any text, we can
+    // either style the placeholder or hide it.
+    // Class with styling to spacing placeholder.
+    if (!contentState.hasText()) {
+      switch (
+        contentState
+          .getBlockMap()
+          .first()
+          .getType()
+      ) {
+        case "ordered-list-item":
+        case "unordered-list-item":
+          classEditor += " placeholder-list";
+          break;
+        case "header-two":
+          classEditor += " placeholder-header-two";
+          break;
+        case "blockquote":
+          classEditor += " placeholder-blockquote";
+          break;
+      }
+    }
+    return classEditor;
+  }
+
   componentWillUnmount() {
     clearTimeout(this.blurTimeoutID);
   }
@@ -387,40 +415,14 @@ export default class MegadraftEditor extends Component {
   render() {
     const hideSidebarOnBlur = this.props.hideSidebarOnBlur || false;
     const i18n = this.props.i18n[this.props.language];
-    let classEditor = "megadraft-editor";
-    let contentState = this.props.editorState.getCurrentContent();
-
-    // If the user changes block type before entering any text, we can
-    // either style the placeholder or hide it.
-    // Class with styling to spacing placeholder.
-    if (!contentState.hasText()) {
-      switch (
-        contentState
-          .getBlockMap()
-          .first()
-          .getType()
-      ) {
-        case "ordered-list-item":
-        case "unordered-list-item":
-          classEditor += " placeholder-list";
-          break;
-        case "header-two":
-          classEditor += " placeholder-header-two";
-          break;
-        case "blockquote":
-          classEditor += " placeholder-blockquote";
-          break;
-        default:
-          classEditor += "";
-          break;
-      }
-    }
+    const classEditor = "megadraft";
+    const identifierEditor = `${classEditor}-editor`;
 
     return (
-      <div className="megadraft">
+      <div className={classEditor}>
         <div
-          className={classEditor}
-          id={this.props.id || "megadraft-editor"}
+          className={this.handleClassEditor(identifierEditor)}
+          id={this.props.id || identifierEditor}
           ref={el => {
             this.editorEl = el;
           }}

--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -387,10 +387,39 @@ export default class MegadraftEditor extends Component {
   render() {
     const hideSidebarOnBlur = this.props.hideSidebarOnBlur || false;
     const i18n = this.props.i18n[this.props.language];
+    let classEditor = "megadraft-editor";
+    let contentState = this.props.editorState.getCurrentContent();
+
+    // If the user changes block type before entering any text, we can
+    // either style the placeholder or hide it.
+    // Class with styling to spacing placeholder.
+    if (!contentState.hasText()) {
+      switch (
+        contentState
+          .getBlockMap()
+          .first()
+          .getType()
+      ) {
+        case "ordered-list-item":
+        case "unordered-list-item":
+          classEditor += " placeholder-list";
+          break;
+        case "header-two":
+          classEditor += " placeholder-header-two";
+          break;
+        case "blockquote":
+          classEditor += " placeholder-blockquote";
+          break;
+        default:
+          classEditor += "";
+          break;
+      }
+    }
+
     return (
       <div className="megadraft">
         <div
-          className="megadraft-editor"
+          className={classEditor}
           id={this.props.id || "megadraft-editor"}
           ref={el => {
             this.editorEl = el;

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -56,6 +56,26 @@
     z-index: 0;
 }
 
+&.placeholder-list {
+  .public-DraftEditorPlaceholder-root {
+    left: 50px;
+    top: 5px;
+  }
+}
+
+&.placeholder-header-two {
+  .public-DraftEditorPlaceholder-root {
+    top: 2px;
+  }
+}
+
+&.placeholder-blockquote {
+  .public-DraftEditorPlaceholder-root {
+    left: 20px;
+    top: 7px;
+  }
+}
+
 blockquote {
     border-left: 2px solid #ddd;
     color: #999;


### PR DESCRIPTION
## Problem

[Bad rendering when attempting to remove a blockquote #187](https://github.com/globocom/megadraft/issues/187)
When you clear the editor and start typing something show a text placeholder
But if you use another type of text has a bug
___
## Reproduce

![Problem](https://i.imgur.com/456PmDL.gif)
___
## Solution

[Draft.js](https://draftjs.org) default hides text placeholder with a class and doesn't has spacing style
But, I created a switch case to push a class on each type with a position

![Solution](https://i.imgur.com/PovUkkE.gif)