### PR TITLE
BUGFIX - Fix read only state on image block

### DIFF
--- a/src/components/plugin/BlockInput.js
+++ b/src/components/plugin/BlockInput.js
@@ -23,16 +23,21 @@ export default class BlockInput extends Component {
   }
 
   render() {
-    let { value, error, styles, ...props } = this.props;
-    styles = styles || {};
+    let {
+      value,
+      error,
+      styles: { padding, text } = {},
+      readOnly,
+      ...props
+    } = this.props;
 
     let className = classNames({
       block__input: true,
       "block__input--empty": !value,
       "block__input--error": error,
-      [`block__input--${styles.padding}-padding`]: styles.padding,
-      [`block__input--${styles.text}-text`]: styles.text,
-      "block__input--readonly": props.readOnly
+      [`block__input--${padding}-padding`]: padding,
+      [`block__input--${text}-text`]: text,
+      "block__input--readonly": readOnly
     });
 
     return (

--- a/src/components/plugin/BlockInput.js
+++ b/src/components/plugin/BlockInput.js
@@ -49,6 +49,7 @@ export default class BlockInput extends Component {
             type={props.type || "text"}
             className={className}
             onDrop={this._handleDrop}
+            readOnly={readOnly}
           />
           <icons.EditIcon className="block__input__icon" />
         </div>

--- a/src/components/plugin/CommonBlock.js
+++ b/src/components/plugin/CommonBlock.js
@@ -37,9 +37,7 @@ export default class CommonBlock extends Component {
     let options = this.props.blockProps.plugin.options || {};
     options = { ...defaults, ...options };
 
-    const readOnly = this.props.blockProps
-      ? this.props.blockProps.getReadOnly()
-      : false;
+    const readOnly = this.props.blockProps.getInitialReadOnly();
 
     return (
       <BlockWrapper readOnly={readOnly}>

--- a/src/plugins/image/ImageBlock.js
+++ b/src/plugins/image/ImageBlock.js
@@ -44,9 +44,7 @@ export default class ImageBlock extends Component {
   }
 
   render() {
-    const readOnly = this.props.blockProps
-      ? this.props.blockProps.getReadOnly()
-      : false;
+    const readOnly = this.props.blockProps.getInitialReadOnly();
 
     return (
       <CommonBlock {...this.props} actions={this.actions}>

--- a/tests/components/Media_test.js
+++ b/tests/components/Media_test.js
@@ -46,7 +46,7 @@ describe("Media Component", () => {
     testContext.blockProps.plugin = DEFAULT_PLUGINS[0];
     testContext.blockProps.onChange = jest.fn();
     testContext.blockProps.setRea = jest.fn();
-    testContext.blockProps.getReadOnly = jest.fn();
+    testContext.blockProps.getInitialReadOnly = jest.fn();
     testContext.blockProps.getEditorState = () => testContext.editorState;
 
     const currentContent = testContext.blockProps.editorState.getCurrentContent();

--- a/tests/components/plugin/CommonBlock_test.js
+++ b/tests/components/plugin/CommonBlock_test.js
@@ -28,7 +28,7 @@ describe("CommonBlock Component", () => {
     const defaultDisplay = "medium";
     const blockProps = {
       plugin: { options: { displayOptions, defaultDisplay } },
-      getReadOnly: jest.fn()
+      getInitialReadOnly: jest.fn()
     };
 
     testContext.container = {

--- a/tests/plugins/image/ImageBlock_test.js
+++ b/tests/plugins/image/ImageBlock_test.js
@@ -31,7 +31,7 @@ describe("ImageBlock", () => {
     const defaultDisplay = "medium";
     const blockProps = {
       plugin: { options: { displayOptions, defaultDisplay } },
-      getReadOnly: jest.fn()
+      getInitialReadOnly: jest.fn()
     };
 
     testContext.wrapper = mount(


### PR DESCRIPTION
Fix for bug caused by https://github.com/globocom/megadraft/commit/8db42aebb15b2712970856162b6c91709b1f772a

When focus on description fields of image block this trigger to change read only state for another control.

This PR fix using the initial read only state. 

(sorry about that :/)