### PR TITLE
Selection state on image block (close #27)

### DIFF
--- a/src/components/plugin/BlockWrapper.js
+++ b/src/components/plugin/BlockWrapper.js
@@ -8,13 +8,18 @@ import React, { Component } from "react";
 
 export default class BlockWrapper extends Component {
   render() {
+    const { style = {}, ...propsForward } = this.props.propsForward;
+
     return (
       <div
         className={
           this.props.readOnly ? "block__hover--readonly" : "block__hover"
         }
+        {...propsForward}
       >
-        <div className="block__wrapper">{this.props.children}</div>
+        <div className="block__wrapper" style={style}>
+          {this.props.children}
+        </div>
       </div>
     );
   }

--- a/src/components/plugin/CommonBlock.js
+++ b/src/components/plugin/CommonBlock.js
@@ -39,8 +39,18 @@ export default class CommonBlock extends Component {
 
     const readOnly = this.props.blockProps.getInitialReadOnly();
 
+    const propsForward = (({ style, tabIndex, onFocus, onBlur }) => ({
+      style,
+      tabIndex,
+      onFocus,
+      onBlur
+    }))(this.props);
+
     return (
-      <BlockWrapper readOnly={readOnly}>
+      <BlockWrapper
+        readOnly={readOnly}
+        propsForward={readOnly ? {} : propsForward}
+      >
         {!readOnly && (
           <BlockControls>
             <Dropdown

--- a/src/plugins/image/ImageBlock.js
+++ b/src/plugins/image/ImageBlock.js
@@ -24,6 +24,10 @@ export default class ImageBlock extends Component {
     this._handleCaptionChange = ::this._handleCaptionChange;
     this._handleRightsHolderChange = ::this._handleRightsHolderChange;
 
+    this.state = {
+      isSelected: false
+    };
+
     this.actions = [
       {
         key: "delete",
@@ -47,7 +51,14 @@ export default class ImageBlock extends Component {
     const readOnly = this.props.blockProps.getInitialReadOnly();
 
     return (
-      <CommonBlock {...this.props} actions={this.actions}>
+      <CommonBlock
+        {...this.props}
+        actions={this.actions}
+        style={this.state.isSelected ? ImageBlockStyle.selected : {}}
+        tabIndex={0}
+        onFocus={() => this.setState({ isSelected: true })}
+        onBlur={() => this.setState({ isSelected: false })}
+      >
         <BlockContent>
           <img style={ImageBlockStyle.image} src={this.props.data.src} alt="" />
         </BlockContent>

--- a/src/plugins/image/ImageBlockStyle.js
+++ b/src/plugins/image/ImageBlockStyle.js
@@ -9,5 +9,8 @@ export default {
     display: "inline-block", // Eliminates whitespace between block and data fields block
     maxWidth: "100%",
     verticalAlign: "middle"
+  },
+  selected: {
+    border: "2px solid #1d69de"
   }
 };

--- a/src/plugins/image/ImageBlockStyle.js
+++ b/src/plugins/image/ImageBlockStyle.js
@@ -11,6 +11,6 @@ export default {
     verticalAlign: "middle"
   },
   selected: {
-    border: "2px solid #1d69de"
+    outline: "auto #1d69de"
   }
 };

--- a/tests/plugins/image/ImageBlock_test.js
+++ b/tests/plugins/image/ImageBlock_test.js
@@ -23,6 +23,7 @@ describe("ImageBlock", () => {
     testContext.setReadOnly = jest.fn();
     testContext.updateData = jest.fn();
     testContext.remove = jest.fn();
+    testContext.setState = jest.fn();
 
     const displayOptions = [
       { key: "small", icon: icons.MediaSmallIcon, label: "SMALL" },
@@ -72,5 +73,15 @@ describe("ImageBlock", () => {
     expect(testContext.updateData).toHaveBeenCalledWith({
       rightsHolder: "new rights"
     });
+  });
+
+  it("change selection state on focus and on blur", () => {
+    expect(testContext.wrapper.state("isSelected")).toBeFalsy();
+
+    testContext.wrapper.simulate("focus");
+    expect(testContext.wrapper.state("isSelected")).toBeTruthy();
+
+    testContext.wrapper.simulate("blur");
+    expect(testContext.wrapper.state("isSelected")).toBeFalsy();
   });
 });


### PR DESCRIPTION
Related Issue #27 

Apply style by selection state to the image block.

![imageblock](https://user-images.githubusercontent.com/6810985/67445163-34dfb180-f5e2-11e9-82d6-32a7939e16b2.png)

Used selected react state on ImageBlock component and forward event handlers and properties until BlockWrapper for handle with select state and style.