### PR TITLE
Avoid preventDefault int Toolbar for select input

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -310,7 +310,10 @@ export default class Toolbar extends Component {
               this.toolbarEl = el;
             }}
             onMouseDown={e => {
-              if (e.target.localName !== "input") {
+              if (
+                e.target.localName !== "input" &&
+                e.target.localName !== "select"
+              ) {
                 e.preventDefault();
               }
             }}


### PR DESCRIPTION
Hello, 
I had an issue when creating an Entity input with a select input inside, with the preventDefault from onMouseDown inside Toolbar, the select input won't open.
Tell me if everything is ok for you :)
