### PR TITLE
refactor: Remove legacy context api

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "webpack-dev-server": "^3.4.1"
   },
   "peerDependencies": {
-    "react": "^15.6.1 || ^16.1.0",
-    "react-dom": "^15.6.1 || ^16.1.0"
+    "react": "^16.1.0",
+    "react-dom": "^16.1.0"
   },
   "scripts": {
     "start": "gulp dev-server",

--- a/src/components/ActionsProvider.js
+++ b/src/components/ActionsProvider.js
@@ -7,42 +7,18 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-export default class ActionsProvider extends React.Component {
-  constructor(props) {
-    super(props);
-  }
+const noop = () => {};
 
-  getChildContext() {
-    return {
-      onAction: this.props.onAction
-    };
-  }
+export const ActionsContext = React.createContext({ onAction: noop });
 
-  render() {
-    return this.props.children;
-  }
-}
+const ActionsProvider = ({ onAction = noop, children }) => (
+  <ActionsContext.Provider value={{ onAction }}>
+    {children}
+  </ActionsContext.Provider>
+);
 
-ActionsProvider.childContextTypes = {
+ActionsProvider.propTypes = {
   onAction: PropTypes.func
 };
 
-export function withActions(WrappedComponent) {
-  class WithActionsHOC extends React.Component {
-    constructor(props) {
-      super(props);
-    }
-
-    render() {
-      return (
-        <WrappedComponent onAction={this.context.onAction} {...this.props} />
-      );
-    }
-  }
-
-  WithActionsHOC.contextTypes = {
-    onAction: PropTypes.func
-  };
-
-  return WithActionsHOC;
-}
+export default ActionsProvider;

--- a/src/components/ActionsProvider.js
+++ b/src/components/ActionsProvider.js
@@ -7,11 +7,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const noop = () => {};
+export const defaultAction = () => {};
 
-export const ActionsContext = React.createContext({ onAction: noop });
+export const ActionsContext = React.createContext({ onAction: defaultAction });
 
-const ActionsProvider = ({ onAction = noop, children }) => (
+const ActionsProvider = ({ onAction = defaultAction, children }) => (
   <ActionsContext.Provider value={{ onAction }}>
     {children}
   </ActionsContext.Provider>

--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -47,8 +47,6 @@ import ActionsProvider from "./ActionsProvider";
 
 const NO_RESET_STYLE_DEFAULT = ["ordered-list-item", "unordered-list-item"];
 
-const noop = () => {};
-
 export default class MegadraftEditor extends Component {
   static defaultProps = {
     actions: DEFAULT_ACTIONS,
@@ -91,7 +89,7 @@ export default class MegadraftEditor extends Component {
 
     this.keyBindings = this.props.keyBindings || [];
 
-    this.onAction = this.props.onAction || noop;
+    this.onAction = this.props.onAction;
 
     this.extendedBlockRenderMap = Immutable.OrderedMap().withMutations(r => {
       for (let [blockType, data] of DefaultDraftBlockRenderMap.entrySeq()) {

--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -43,7 +43,7 @@ import notFoundPlugin from "../plugins/not-found/plugin";
 import DEFAULT_PLUGINS from "../plugins/default";
 import DEFAULT_ACTIONS from "../actions/default";
 import DEFAULT_ENTITY_INPUTS from "../entity_inputs/default";
-import ActionsProvider from "./ActionsProvider";
+import ActionsProvider, { defaultAction } from "./ActionsProvider";
 
 const NO_RESET_STYLE_DEFAULT = ["ordered-list-item", "unordered-list-item"];
 
@@ -89,7 +89,7 @@ export default class MegadraftEditor extends Component {
 
     this.keyBindings = this.props.keyBindings || [];
 
-    this.onAction = this.props.onAction;
+    this.onAction = this.props.onAction || defaultAction;
 
     this.extendedBlockRenderMap = Immutable.OrderedMap().withMutations(r => {
       for (let [blockType, data] of DefaultDraftBlockRenderMap.entrySeq()) {
@@ -102,6 +102,7 @@ export default class MegadraftEditor extends Component {
               swapDown={this.swapDown}
               isFirstBlock={this.isFirstBlock}
               isLastBlock={this.isLastBlock}
+              onAction={this.onAction}
             />
           ) : (
             <MegadraftBlock wrapper={data.wrapper} />

--- a/src/components/ModalPluginItem.js
+++ b/src/components/ModalPluginItem.js
@@ -6,10 +6,12 @@
 
 import React, { Component } from "react";
 
-import { withActions } from "./ActionsProvider";
+import { ActionsContext } from "./ActionsProvider";
 import { PLUGINS_MODAL_ADD_PLUGIN } from "../constants";
 
-class ModalPluginItem extends Component {
+export default class ModalPluginItem extends Component {
+  static contextType = ActionsContext;
+
   constructor(props) {
     super(props);
     this.handleClick = ::this.handleClick;
@@ -33,7 +35,7 @@ class ModalPluginItem extends Component {
         key={item.type}
         className="megadraft-modal__item"
         onClick={() => {
-          this.props.onAction({
+          this.context.onAction({
             type: PLUGINS_MODAL_ADD_PLUGIN,
             pluginName: item.title
           });
@@ -67,5 +69,3 @@ class ModalPluginItem extends Component {
     );
   }
 }
-
-export default withActions(ModalPluginItem);

--- a/src/components/MoveControl.js
+++ b/src/components/MoveControl.js
@@ -4,21 +4,15 @@
  * License: MIT
  */
 
-import React from "react";
+import React, { useContext } from "react";
 import icons from "../icons";
 import MegadraftBlock from "./MegadraftBlock";
-import { withActions } from "./ActionsProvider";
+import { ActionsContext } from "./ActionsProvider";
 
 import { BLOCK_SWAP_UP, BLOCK_SWAP_DOWN } from "../constants";
 
-const Options = ({
-  onClickUp,
-  onClickDown,
-  id,
-  disableUp,
-  disableDown,
-  onAction
-}) => {
+const Options = ({ onClickUp, onClickDown, id, disableUp, disableDown }) => {
+  const { onAction } = useContext(ActionsContext);
   const onPointerDown = e => {
     e.preventDefault();
     e.stopPropagation();
@@ -53,21 +47,13 @@ const Options = ({
   );
 };
 
-const Control = ({
-  children,
-  id,
-  onClickUp,
-  onClickDown,
-  isFirst,
-  isLast,
-  onAction
-}) => (
+const Control = ({ children, id, onClickUp, onClickDown, isFirst, isLast }) => (
   <div className="move-control" id={`move-control-${id}`}>
     <div className="move-control__target" data-testid={`block-${id}`}>
       {children}
     </div>
     <Options
-      {...{ id, onClickUp, onClickDown, onAction }}
+      {...{ id, onClickUp, onClickDown }}
       disableUp={isFirst}
       disableDown={isLast}
     />
@@ -81,8 +67,7 @@ const Controlled = ({
   isLastBlock,
   swapUp,
   swapDown,
-  children,
-  onAction
+  children
 }) => {
   const onClickUp = () => swapUp(keySwapUp);
   const onClickDown = () => swapDown(keySwapDown);
@@ -95,7 +80,7 @@ const Controlled = ({
         id={
           keySwapUp !== keySwapDown ? `${keySwapUp}-${keySwapDown}` : keySwapUp
         }
-        {...{ onClickUp, onClickDown, isFirst, isLast, onAction }}
+        {...{ onClickUp, onClickDown, isFirst, isLast }}
       >
         {children}
       </Control>
@@ -103,44 +88,41 @@ const Controlled = ({
   );
 };
 
-export default withActions(
-  ({
-    wrapper,
-    swapUp,
-    swapDown,
-    children,
-    isFirstBlock,
-    isLastBlock,
-    onAction
-  }) => {
-    const arrayChildren = React.Children.toArray(children);
-    const firstChildKey = arrayChildren[0].props.children.key;
-    const lastChildKey =
-      arrayChildren[arrayChildren.length - 1].props.children.key;
+export default ({
+  wrapper,
+  swapUp,
+  swapDown,
+  children,
+  isFirstBlock,
+  isLastBlock
+}) => {
+  const arrayChildren = React.Children.toArray(children);
+  const firstChildKey = arrayChildren[0].props.children.key;
+  const lastChildKey =
+    arrayChildren[arrayChildren.length - 1].props.children.key;
 
-    const controlledChildren = React.Children.map(children, child => {
-      const currentKey = child.props.children.key;
-      return (
-        <Controlled
-          keySwapUp={currentKey}
-          keySwapDown={currentKey}
-          {...{ swapUp, swapDown, isFirstBlock, isLastBlock, onAction }}
-        >
-          {child}
-        </Controlled>
-      );
-    });
-
-    return wrapper ? (
+  const controlledChildren = React.Children.map(children, child => {
+    const currentKey = child.props.children.key;
+    return (
       <Controlled
-        keySwapUp={firstChildKey}
-        keySwapDown={lastChildKey}
-        {...{ swapUp, swapDown, isFirstBlock, isLastBlock, onAction }}
+        keySwapUp={currentKey}
+        keySwapDown={currentKey}
+        {...{ swapUp, swapDown, isFirstBlock, isLastBlock }}
       >
-        {React.cloneElement(wrapper, [], children)}
+        {child}
       </Controlled>
-    ) : (
-      controlledChildren
     );
-  }
-);
+  });
+
+  return wrapper ? (
+    <Controlled
+      keySwapUp={firstChildKey}
+      keySwapDown={lastChildKey}
+      {...{ swapUp, swapDown, isFirstBlock, isLastBlock }}
+    >
+      {React.cloneElement(wrapper, [], children)}
+    </Controlled>
+  ) : (
+    controlledChildren
+  );
+};

--- a/src/components/MoveControl.js
+++ b/src/components/MoveControl.js
@@ -4,15 +4,20 @@
  * License: MIT
  */
 
-import React, { useContext } from "react";
+import React from "react";
 import icons from "../icons";
 import MegadraftBlock from "./MegadraftBlock";
-import { ActionsContext } from "./ActionsProvider";
 
 import { BLOCK_SWAP_UP, BLOCK_SWAP_DOWN } from "../constants";
 
-const Options = ({ onClickUp, onClickDown, id, disableUp, disableDown }) => {
-  const { onAction } = useContext(ActionsContext);
+const Options = ({
+  onClickUp,
+  onClickDown,
+  id,
+  disableUp,
+  disableDown,
+  onAction
+}) => {
   const onPointerDown = e => {
     e.preventDefault();
     e.stopPropagation();
@@ -47,13 +52,21 @@ const Options = ({ onClickUp, onClickDown, id, disableUp, disableDown }) => {
   );
 };
 
-const Control = ({ children, id, onClickUp, onClickDown, isFirst, isLast }) => (
+const Control = ({
+  children,
+  id,
+  onClickUp,
+  onClickDown,
+  isFirst,
+  isLast,
+  onAction
+}) => (
   <div className="move-control" id={`move-control-${id}`}>
     <div className="move-control__target" data-testid={`block-${id}`}>
       {children}
     </div>
     <Options
-      {...{ id, onClickUp, onClickDown }}
+      {...{ id, onClickUp, onClickDown, onAction }}
       disableUp={isFirst}
       disableDown={isLast}
     />
@@ -67,6 +80,7 @@ const Controlled = ({
   isLastBlock,
   swapUp,
   swapDown,
+  onAction,
   children
 }) => {
   const onClickUp = () => swapUp(keySwapUp);
@@ -80,7 +94,7 @@ const Controlled = ({
         id={
           keySwapUp !== keySwapDown ? `${keySwapUp}-${keySwapDown}` : keySwapUp
         }
-        {...{ onClickUp, onClickDown, isFirst, isLast }}
+        {...{ onClickUp, onClickDown, isFirst, isLast, onAction }}
       >
         {children}
       </Control>
@@ -94,7 +108,8 @@ export default ({
   swapDown,
   children,
   isFirstBlock,
-  isLastBlock
+  isLastBlock,
+  onAction
 }) => {
   const arrayChildren = React.Children.toArray(children);
   const firstChildKey = arrayChildren[0].props.children.key;
@@ -107,7 +122,7 @@ export default ({
       <Controlled
         keySwapUp={currentKey}
         keySwapDown={currentKey}
-        {...{ swapUp, swapDown, isFirstBlock, isLastBlock }}
+        {...{ swapUp, swapDown, isFirstBlock, isLastBlock, onAction }}
       >
         {child}
       </Controlled>
@@ -118,7 +133,7 @@ export default ({
     <Controlled
       keySwapUp={firstChildKey}
       keySwapDown={lastChildKey}
-      {...{ swapUp, swapDown, isFirstBlock, isLastBlock }}
+      {...{ swapUp, swapDown, isFirstBlock, isLastBlock, onAction }}
     >
       {React.cloneElement(wrapper, [], children)}
     </Controlled>

--- a/src/components/PluginsModal.js
+++ b/src/components/PluginsModal.js
@@ -9,10 +9,12 @@ import React, { Component } from "react";
 import Modal from "backstage-modal";
 import ModalPluginList from "./ModalPluginList";
 
-import { withActions } from "./ActionsProvider";
+import { ActionsContext } from "./ActionsProvider";
 import { PLUGINS_MODAL_CLOSE } from "../constants";
 
-class PluginsModal extends Component {
+export default class PluginsModal extends Component {
+  static contextType = ActionsContext;
+
   constructor(props) {
     super(props);
     this.onCloseRequest = ::this.onCloseRequest;
@@ -26,7 +28,7 @@ class PluginsModal extends Component {
       return;
     }
     document.body.classList.remove("megadraft-modal--open");
-    this.props.onAction({ type: PLUGINS_MODAL_CLOSE });
+    this.context.onAction({ type: PLUGINS_MODAL_CLOSE });
     this.props.toggleModalVisibility();
   }
 
@@ -52,5 +54,3 @@ class PluginsModal extends Component {
     );
   }
 }
-
-export default withActions(PluginsModal);

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -16,14 +16,16 @@ import {
   SIDEBAR_CLICK_MORE
 } from "../constants";
 
-import { withActions } from "./ActionsProvider";
+import { ActionsContext } from "./ActionsProvider";
 
 import "setimmediate";
 
 import PluginsModal from "./PluginsModal";
 import { getSelectedBlockElement } from "../utils";
 
-class BlockStylesComponent extends Component {
+class BlockStyles extends Component {
+  static contextType = ActionsContext;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -70,7 +72,7 @@ class BlockStylesComponent extends Component {
       <button
         className="sidemenu__button"
         onClick={e => {
-          this.props.onAction({ type: SIDEBAR_CLICK_MORE });
+          this.context.onAction({ type: SIDEBAR_CLICK_MORE });
           this.onModalOpenClick(e);
         }}
       >
@@ -87,7 +89,7 @@ class BlockStylesComponent extends Component {
         key={item.type}
         className="sidemenu__item"
         onClick={() => {
-          this.props.onAction({
+          this.context.onAction({
             type: SIDEBAR_ADD_PLUGIN,
             pluginName: item.title
           });
@@ -130,7 +132,6 @@ class BlockStylesComponent extends Component {
     );
   }
 }
-export const BlockStyles = withActions(BlockStylesComponent);
 
 export class ToggleButton extends Component {
   render() {
@@ -162,7 +163,9 @@ export class ToggleButton extends Component {
   }
 }
 
-class SideMenuComponent extends Component {
+export class SideMenu extends Component {
+  static contextType = ActionsContext;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -177,7 +180,7 @@ class SideMenuComponent extends Component {
   }
 
   toggle() {
-    this.props.onAction({
+    this.context.onAction({
       type: this.state.open ? SIDEBAR_SHRINK : SIDEBAR_EXPAND
     });
     this.setState({
@@ -211,7 +214,6 @@ class SideMenuComponent extends Component {
     );
   }
 }
-export const SideMenu = withActions(SideMenuComponent);
 
 export default class SideBar extends Component {
   constructor(props) {

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -699,40 +699,6 @@ describe("MegadraftEditor Component", () => {
     expect(sidebar.prop("readOnly")).toBeFalsy();
   });
 
-  it("should have a default function to onAction prop", () => {
-    const wrapper = mount(
-      <MegadraftEditor
-        editorState={testContext.editorState}
-        onChange={testContext.onChange}
-      />
-    );
-
-    const onAction = wrapper.instance().onAction;
-    const sideMenuComponent = wrapper.find("SideMenuComponent");
-
-    expect(onAction).toBeDefined();
-    expect(typeof onAction).toBe("function");
-    expect(sideMenuComponent.prop("onAction")).toEqual(onAction);
-  });
-
-  it("should pass a custom onAction prop to Sidebar", () => {
-    const customOnAction = jest.fn();
-    const wrapper = mount(
-      <MegadraftEditor
-        editorState={testContext.editorState}
-        onChange={testContext.onChange}
-        onAction={customOnAction}
-      />
-    );
-
-    const onAction = wrapper.instance().onAction;
-    const sideMenuComponent = wrapper.find("SideMenuComponent");
-
-    expect(onAction).toBeDefined();
-    expect(onAction).toEqual(customOnAction);
-    expect(sideMenuComponent.prop("onAction")).toEqual(customOnAction);
-  });
-
   it("calls sidebarRendererFn if it's provided", () => {
     const renderCustomSidebar = jest.fn();
     const wrapper = mount(


### PR DESCRIPTION
To paraphrase the [documentation](https://pt-br.reactjs.org/docs/legacy-context.html#updating-context): **Don’t do it**.

Closes #288