### PR TITLE
Remove return type annotation on method `externalKeyBindings`

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -148,7 +148,7 @@ export default class MegadraftEditor extends Component {
     this.props.onChange(editorState);
   }
 
-  externalKeyBindings(e): string {
+  externalKeyBindings(e) {
     for (const kb of this.keyBindings) {
       if (kb.isKeyBound(e)) {
         return kb.name;


### PR DESCRIPTION
## Related Issue
None

## Proposed Changes

  - Remove TypeScript-only feature on a JavaScript file