### PR TITLE
Prevent `false` from being appended into Control's component className

### DIFF
--- a/src/components/MoveControl.js
+++ b/src/components/MoveControl.js
@@ -5,6 +5,7 @@
  */
 
 import React from "react";
+import classNames from "classnames";
 import icons from "../icons";
 import MegadraftBlock from "./MegadraftBlock";
 
@@ -69,7 +70,7 @@ const Control = ({
   isAtomic
 }) => (
   <div
-    className={`move-control ${isAtomic && "move-control--atomic"}`}
+    className={classNames("move-control", isAtomic && "move-control--atomic")}
     id={`move-control-${id}`}
   >
     <div className="move-control__target" data-testid={`block-${id}`}>


### PR DESCRIPTION
## Proposed Changes

  - Control component was using string literals in order to interpolate a condition class name. This was leading to a `false` className being appended when the condition is false (due to interpolation boolean interpretation). This PR uses the already installed `classnames` package to prevent this.
