### PR TITLE
Fix movable blocks when editor is readOnly

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -98,19 +98,20 @@ export default class MegadraftEditor extends Component {
       for (let [blockType, data] of DefaultDraftBlockRenderMap.entrySeq()) {
         r.set(blockType, {
           ...data,
-          wrapper: this.props.movableBlocks ? (
-            <MoveControl
-              wrapper={data.wrapper}
-              swapUp={this.swapUp}
-              swapDown={this.swapDown}
-              isFirstBlock={this.isFirstBlock}
-              isLastBlock={this.isLastBlock}
-              onAction={this.onAction}
-              isAtomic={blockType === "atomic"}
-            />
-          ) : (
-            <MegadraftBlock wrapper={data.wrapper} />
-          )
+          wrapper:
+            !this.props.readOnly && this.props.movableBlocks ? (
+              <MoveControl
+                wrapper={data.wrapper}
+                swapUp={this.swapUp}
+                swapDown={this.swapDown}
+                isFirstBlock={this.isFirstBlock}
+                isLastBlock={this.isLastBlock}
+                onAction={this.onAction}
+                isAtomic={blockType === "atomic"}
+              />
+            ) : (
+              <MegadraftBlock wrapper={data.wrapper} />
+            )
         });
       }
     });

--- a/tests/components/MegadraftEditor_test.js
+++ b/tests/components/MegadraftEditor_test.js
@@ -838,6 +838,18 @@ describe("MegadraftEditor Component", () => {
       );
     };
 
+    it("should not render MoveControl when readOnly is present", () => {
+      const wrapper = mount(
+        <MegadraftEditor
+          editorState={testContext.editorState}
+          onChange={testContext.onChange}
+          readOnly
+          movableBlocks
+        />
+      );
+      expect(wrapper.find(".move-control").exists()).toBeFalsy();
+    });
+
     it("with the top block by clicking the up control", () => {
       const expected = [
           "block-kst0",


### PR DESCRIPTION
## Related Issue
Fixes #314 

## Proposed Changes
  - props readOnly should not be present to enable movable blocks
