### PR TITLE
Hide placeholders and edit buttons in readOnly mode in case there is no content

### DIFF
--- a/src/styles/block.scss
+++ b/src/styles/block.scss
@@ -188,18 +188,17 @@
 
   // Read Only
   &--readonly,
-  &--readonly.block__input--empty,
-  &--readonly:hover {
+  &--readonly:focus,
+  &--readonly:hover,
+  &--readonly.block__input--empty {
     border: none;
-  }
-  &--readonly:hover + svg.block__input__icon {
-    display: none;
-  }
 
-  &--readonly:focus {
-    border: none;
-  }
-  &--readonly:focus + svg.block__input__icon {
-    display: none;
+    &::placeholder {
+      color: transparent;
+    }
+
+    & + svg.block__input__icon {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
With empty caption/rights holder it renders placeholder and edit icon. With proposed changes, it does not.

## Related Issue
#82 
