### PR TITLE
Styling and placeholder fix

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -356,10 +356,10 @@ export default class MegadraftEditor extends Component {
   }
 
   handleClassEditor(identifier) {
-    let classEditor = this.props.movableBlocks
+    const classEditor = this.props.movableBlocks
       ? `${identifier} movable`
       : identifier;
-    let contentState = this.props.editorState.getCurrentContent();
+    const contentState = this.props.editorState.getCurrentContent();
     // If the user changes block type before entering any text, we can
     // either style the placeholder or hide it.
     // Class with styling to spacing placeholder.
@@ -372,14 +372,9 @@ export default class MegadraftEditor extends Component {
       ) {
         case "ordered-list-item":
         case "unordered-list-item":
-          classEditor += " placeholder-list";
-          break;
         case "header-two":
-          classEditor += " placeholder-header-two";
-          break;
         case "blockquote":
-          classEditor += " placeholder-blockquote";
-          break;
+          return `${classEditor} placeholder-hide`;
       }
     }
     return classEditor;

--- a/src/styles/megadraft.scss
+++ b/src/styles/megadraft.scss
@@ -22,17 +22,17 @@
 
     @import "move-control.scss";
 
-    &.placeholder-hide {
-        .public-DraftEditorPlaceholder-root {
-            visibility: hidden;
-        }
+  &.placeholder-hide {
+    .public-DraftEditorPlaceholder-root {
+      visibility: hidden;
     }
+  }
 
-    &.movable {
-        .public-DraftEditorPlaceholder-root {
-            padding: 8px 0 0 8px;
-        }
+  &.movable {
+    .public-DraftEditorPlaceholder-root {
+      padding: 8px 0 0 8px;
     }
+  }
 
     .megadraft-block {
         padding-bottom: 40px;

--- a/src/styles/megadraft.scss
+++ b/src/styles/megadraft.scss
@@ -22,6 +22,18 @@
 
     @import "move-control.scss";
 
+    &.placeholder-hide {
+        .public-DraftEditorPlaceholder-root {
+            visibility: hidden;
+        }
+    }
+
+    &.movable {
+        .public-DraftEditorPlaceholder-root {
+            padding: 8px 0 0 8px;
+        }
+    }
+
     .megadraft-block {
         padding-bottom: 40px;
     }

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -55,38 +55,6 @@
     z-index: 0;
 }
 
-.placeholder-list {
-  .public-DraftEditorPlaceholder-root {
-    left: 50px;
-    top: 5px;
-  }
-}
-
-.placeholder-header-two {
-  .public-DraftEditorPlaceholder-root {
-    top: 2px;
-  }
-}
-
-.placeholder-blockquote {
-  .public-DraftEditorPlaceholder-root {
-    left: 20px;
-    top: 7px;
-  }
-}
-
-.movable {
-  .public-DraftEditorPlaceholder-root {
-    padding: 8px 0 0 8px;
-  }
-}
-
-.movable.placeholder-blockquote {
-  .public-DraftEditorPlaceholder-root {
-    padding: 20px 0 0 10px;
-  }
-}
-
 blockquote {
     border-left: 2px solid #ddd;
     color: #999;


### PR DESCRIPTION
## Related Issue
1. Fixes #319 
2. Fixes: styles movable, placeholder-[list/blockquote/placeholder-header-two] are not working. These css classes are on the same element as megadraft-editor but the current sass setup is for nested classes not multiple classes.