### PR TITLE
Add MIT license badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Megadraft [![Build Status](https://secure.travis-ci.org/globocom/megadraft.png?branch=master)](https://travis-ci.org/globocom/megadraft) [![npm version](https://img.shields.io/npm/v/megadraft.svg?style=flat)](https://www.npmjs.com/package/megadraft)
+# Megadraft [![License: MIT](https://img.shields.io/badge/License-MIT-Green.svg)](https://github.com/globocom/megadraft/blob/master/LICENSE) [![Build Status](https://secure.travis-ci.org/globocom/megadraft.png?branch=master)](https://travis-ci.org/globocom/megadraft) [![npm version](https://img.shields.io/npm/v/megadraft.svg?style=flat)](https://www.npmjs.com/package/megadraft)
 
 Rich Text editor built on top of [Facebook's draft.js](https://github.com/facebook/draft-js)
 


### PR DESCRIPTION
## Related Issue
<!--- Ex: Fixes #123 or Closes #123 -->
No related Issue
## Proposed Changes
- Add the MIT License badge linked with the Repo's license to the top of the README file
