### PR TITLE
Added humanReadable boolean to editorStateToJSON

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -14,10 +14,10 @@ import {
 
 import defaultDecorator from "./decorators/defaultDecorator";
 
-export function editorStateToJSON(editorState) {
+export function editorStateToJSON(editorState, humanReadable = true) {
   if (editorState) {
     const content = editorState.getCurrentContent();
-    return JSON.stringify(convertToRaw(content), null, 2);
+    return JSON.stringify(convertToRaw(content), null, humanReadable ? 2 : 0);
   }
 }
 


### PR DESCRIPTION
editorStateToJSON always returns stringified JSON with indents and newlines. If we want to "minify" this before storing in the database, we need to do something like `JSON.stringify(JSON.parse(editorStateToJSON(editorState)))`

I've added a second parameter to editorStateToJSON, to optionally turn off newlines and indents and allow us to skip this step. It defaults to true, so shouldn't cause any breaking changes