### PR TITLE
Passed setReadOnly to block in order to have the possibility to manipulate editor's editable state

### DIFF
--- a/src/components/Media.js
+++ b/src/components/Media.js
@@ -88,6 +88,7 @@ export default class Media extends Component {
           i18n={i18n}
           setInitialReadOnly={setInitialReadOnly}
           setReadOnly={setReadOnly}
+          options={plugin.options}
         >
           <Block
             i18n={i18n}

--- a/src/components/Media.js
+++ b/src/components/Media.js
@@ -88,13 +88,13 @@ export default class Media extends Component {
           i18n={i18n}
           setInitialReadOnly={setInitialReadOnly}
           setReadOnly={setReadOnly}
-          options={plugin.options}
         >
           <Block
             i18n={i18n}
             data={data}
             container={this}
             blockProps={this.props.blockProps}
+            setReadOnly={setReadOnly}
           />
         </MediaWrapper>
       </ErrorBoundary>

--- a/src/components/MediaWrapper.js
+++ b/src/components/MediaWrapper.js
@@ -16,13 +16,7 @@ export default class MediaWrapper extends Component {
 
   _handleFocus() {
     // temporarily set the editor to readonly
-    if (
-      typeof this.props.options === "undefined" ||
-      typeof this.props.options.alwaysCustomizable === "undefined" ||
-      !this.props.options.alwaysCustomizable
-    ) {
-      this.props.setReadOnly(true);
-    }
+    this.props.setReadOnly(true);
   }
 
   _handleBlur() {

--- a/src/components/MediaWrapper.js
+++ b/src/components/MediaWrapper.js
@@ -16,7 +16,13 @@ export default class MediaWrapper extends Component {
 
   _handleFocus() {
     // temporarily set the editor to readonly
-    this.props.setReadOnly(true);
+    if (
+      typeof this.props.options === "undefined" ||
+      typeof this.props.options.alwaysCustomizable === "undefined" ||
+      !this.props.options.alwaysCustomizable
+    ) {
+      this.props.setReadOnly(true);
+    }
   }
 
   _handleBlur() {


### PR DESCRIPTION
## Related Issue
#338

## Proposed Changes
Pass setReadOnly to Block in order to change readOnly state depending on Modal's open/close state instead of MediaWrapper
