### PR TITLE
Website accessibility improvements

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -119,7 +119,7 @@ class BlockStyles extends Component {
     const className = classNames("sidemenu__items", {
       "sidemenu__items--open": this.props.open
     });
-    return (
+    return this.props.open ? (
       <div>
         <ul style={sidemenuMaxHeight} className={className}>
           {this.props.plugins
@@ -129,7 +129,7 @@ class BlockStyles extends Component {
         </ul>
         {hasModal ? this.renderModal() : null}
       </div>
-    );
+    ) : null;
   }
 }
 
@@ -156,6 +156,7 @@ export class ToggleButton extends Component {
           this.button.focus();
           this.props.toggle();
         }}
+        aria-label={this.props.open ? "Close menu" : "Add new"}
       >
         <Icon className="sidemenu__button__icon" />
       </button>

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -36,7 +36,6 @@
         transition: all 0.5s ease;
         position: relative;
         background: none;
-        outline: none;
 
         &:before {
             content: "";

--- a/website/components/header.js
+++ b/website/components/header.js
@@ -19,6 +19,7 @@ export default class Header extends React.Component {
             <img
               className="hero__logo-svg"
               src="images/megadraft_white_version.svg"
+              alt="Megadraft logo"
             />
           </div>
           <h1 className="hero__title">

--- a/website/index_tpl.html
+++ b/website/index_tpl.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Megadraft - Draft.JS Rich Text Editor</title>

--- a/website/styles/_base.scss
+++ b/website/styles/_base.scss
@@ -79,10 +79,6 @@ body {
   font-family: 'Roboto', sans-serif;
 }
 
-:focus {
-    outline: none
-}
-
 @font-face {
   font-family: "Abril Fatface";
   src: url("../fonts/AbrilFatface-Regular.otf");


### PR DESCRIPTION
## Related Issue
None

## Proposed Changes

  - Remove the `outline:none` from the plugin button's focused state. It was practically impossible to navigate these buttons with the keyboard without outlines. I also propose adding a condition to only render the "collapsed" state if the user clicks the "+" button instead of having it rendered all the time but not visible. Check the demo bellow;

https://user-images.githubusercontent.com/9519976/135757298-a4170dea-34be-4abf-b77e-f495c89d9cab.mov

  - Add the `aria-label` attribute to the "+/x" button to indicate the respective action to screen readers;
  - Add alt text to the logo so screen readers can understand it's a logo;
  - Add the `lang` property to the `html` tag to indicate the content's language declaratively.

This is the Lighthouse rating before the changes:
![image](https://user-images.githubusercontent.com/9519976/135757005-06574cd1-4d5c-49ef-bcf2-c6eae9e12159.png)

After the changes:
![image](https://user-images.githubusercontent.com/9519976/135757040-763bbc3a-0850-4f16-a1c7-ad61cda1af53.png)

Here you can see some improvement on **SEO** and **Performance** as well.

The **Best Practices** metric went down due to dev environment not using HTTPs. It should be good live.