### PR TITLE
fix: add UNSAFE_ prefix to legacy life cycle methods in React 17

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -139,7 +139,7 @@ export default class MegadraftEditor extends Component {
     return pluginsByType;
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.readOnly !== nextProps.readOnly) {
       this.setState({ readOnly: nextProps.readOnly });
     }

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -161,7 +161,7 @@ export default class Toolbar extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const currentContentState = this.props.editorState.getCurrentContent();
     const newContentState = nextProps.editorState.getCurrentContent();
 

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -234,7 +234,7 @@ describe("Toolbar Component", () => {
 
         const toolbar = wrapper.find(Toolbar);
         const nextProps = { editorState: { getCurrentContent: () => "blah" } };
-        toolbar.instance().componentWillReceiveProps(nextProps);
+        toolbar.instance().UNSAFE_componentWillReceiveProps(nextProps);
         expect(toolbar.instance().state.show).toBeTruthy();
       });
 


### PR DESCRIPTION
## Proposed Changes
  - Fix warnings related to legacy component lifecycles on React 17 renaming methods with the prefix `UNSAFE_` (https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path)
  

