### PR TITLE
reafactor: remove deprecated method

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -67,7 +67,6 @@ export default class MegadraftEditor extends Component {
     };
 
     this.onChange = this.onChange.bind(this);
-    this.onTab = this.onTab.bind(this);
 
     this.mediaBlockRenderer = this.mediaBlockRenderer.bind(this);
 
@@ -156,12 +155,6 @@ export default class MegadraftEditor extends Component {
       }
     }
     return getDefaultKeyBinding(e);
-  }
-
-  onTab(event) {
-    if (this.props.onTab) {
-      this.props.onTab(event);
-    }
   }
 
   handleKeyCommand(command) {
@@ -558,7 +551,6 @@ export default class MegadraftEditor extends Component {
               readOnly={this.state.readOnly}
               blockRendererFn={this.mediaBlockRenderer}
               blockStyleFn={this.props.blockStyleFn || this.blockStyleFn}
-              onTab={this.onTab}
               handleKeyCommand={this.handleKeyCommand}
               handleReturn={this.props.handleReturn || this.handleReturn}
               keyBindingFn={this.externalKeyBindings}


### PR DESCRIPTION
## Proposed Changes
  - Remove method onTab as it is deprecated since Draft.js v0.11
<img width="1471" alt="Captura de Tela 2021-10-16 às 16 21 41" src="https://user-images.githubusercontent.com/7880548/137600002-0b3641ce-7adb-4925-8096-b937491f8067.png">

Also, got this ref: https://github.com/jpuri/react-draft-wysiwyg/issues/853

