### PR TITLE
refactor(components/dropdown): convert to functional component

### DIFF
--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -4,122 +4,90 @@
  * License: MIT
  */
 
-import React, { Component } from "react";
-import ReactDOM from "react-dom";
+import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 
 import DropdownItem from "./DropdownItem";
 import icons from "../icons";
 
-export default class Dropdown extends Component {
-  static propTypes = {
-    items: PropTypes.arrayOf(
-      PropTypes.shape({
-        key: PropTypes.string.isRequired,
-        icon: PropTypes.func.isRequired,
-        label: PropTypes.string.isRequired
-      })
-    ),
-    selected: PropTypes.string,
-    onChange: PropTypes.func.isRequired
+const Dropdown = ({ items = [], selected, onChange }) => {
+  const wrapperRef = useRef(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const isEmpty = items.length === 0;
+  const selectedItem = items.filter(item => item.key === selected)[0];
+
+  const toggleDropdown = () => setIsOpen(isOpen => !isOpen);
+
+  const handleDocumentClick = event => {
+    if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
+      setIsOpen(false);
+    }
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      isOpen: false
-    };
-    this.handleDocumentClick = this.handleDocumentClick.bind(this);
-    this.toggleDropDown = this.toggleDropDown.bind(this);
-    this.preventSelection = this.preventSelection.bind(this);
-    this.renderItem = this.renderItem.bind(this);
-  }
-
-  isEmpty() {
-    const items = this.props.items || [];
-    return items.length == 0 ? true : false;
-  }
-
-  onChange(selected) {
-    this.props.onChange(selected);
-  }
-
-  renderItem(item) {
-    return (
-      <li key={item.key}>
-        <DropdownItem
-          item={item}
-          className="dropdown__option"
-          onClick={() => this.onChange(item.key)}
-        />
-      </li>
-    );
-  }
-
-  preventSelection(event) {
+  const preventSelection = event => {
     window.getSelection().empty();
     event.preventDefault();
+  };
+
+  useEffect(() => {
+    document.addEventListener("click", handleDocumentClick, false);
+
+    return () =>
+      document.removeEventListener("click", handleDocumentClick, false);
+  }, []);
+
+  if (isEmpty) {
+    return null;
   }
 
-  toggleDropDown(event) {
-    this.setState({ isOpen: !this.state.isOpen });
-  }
+  const wrapperClassName = classNames("dropdown__wrapper", {
+    "dropdown__wrapper--open": isOpen
+  });
 
-  handleDocumentClick(event) {
-    if (this.isEmpty()) {
-      return null;
-    }
-    if (!ReactDOM.findDOMNode(this).contains(event.target)) {
-      this.setState({ isOpen: false });
-    }
-  }
+  const dropdownClassName = classNames("dropdown", {
+    "dropdown--open": isOpen
+  });
 
-  componentDidMount() {
-    document.addEventListener("click", this.handleDocumentClick, false);
-  }
+  const arrowClassName = classNames("dropdown__arrow", {
+    "dropdown__arrow--open": isOpen
+  });
 
-  componentWillUnmount() {
-    document.removeEventListener("click", this.handleDocumentClick, false);
-  }
+  return (
+    <div ref={wrapperRef} className={wrapperClassName} onClick={toggleDropdown}>
+      <DropdownItem
+        item={selectedItem}
+        className="dropdown__item--selected"
+        onMouseDown={preventSelection}
+      >
+        <icons.DropdownArrow className={arrowClassName} />
+      </DropdownItem>
 
-  render() {
-    if (this.isEmpty()) {
-      return null;
-    }
+      <ul className={dropdownClassName}>
+        {items.map(item => (
+          <li key={item.key}>
+            <DropdownItem
+              item={item}
+              className="dropdown__option"
+              onClick={() => onChange(item.key)}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
 
-    const selectedItem = this.props.items.filter(obj => {
-      return obj.key === this.props.selected;
-    })[0];
+Dropdown.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      icon: PropTypes.func.isRequired,
+      label: PropTypes.string.isRequired
+    })
+  ),
+  selected: PropTypes.string,
+  onChange: PropTypes.func.isRequired
+};
 
-    const { isOpen } = this.state;
-
-    const wrapperClassName = classNames("dropdown__wrapper", {
-      "dropdown__wrapper--open": isOpen
-    });
-
-    const dropdownClassName = classNames("dropdown", {
-      "dropdown--open": isOpen
-    });
-
-    const arrowClassName = classNames("dropdown__arrow", {
-      "dropdown__arrow--open": isOpen
-    });
-
-    return (
-      <div className={wrapperClassName} onClick={this.toggleDropDown}>
-        <DropdownItem
-          item={selectedItem}
-          className="dropdown__item--selected"
-          onMouseDown={this.preventSelection}
-        >
-          <icons.DropdownArrow className={arrowClassName} />
-        </DropdownItem>
-
-        <ul className={dropdownClassName}>
-          {this.props.items.map(this.renderItem)}
-        </ul>
-      </div>
-    );
-  }
-}
+export default Dropdown;

--- a/tests/components/Dropdown_test.js
+++ b/tests/components/Dropdown_test.js
@@ -15,15 +15,15 @@ describe("Dropdown Component", () => {
   let testContext;
 
   beforeEach(() => {
-    testContext = {};
-    testContext.selected = "metal";
-    testContext.onChange = jest.fn();
     const dropdownItems = [
       { key: "pagode", icon: icons.MediaMediumIcon, label: "Pagode" },
       { key: "metal", icon: icons.MediaBigIcon, label: "Metal" },
       { key: "samba", icon: icons.MediaSmallIcon, label: "Samba" }
     ];
 
+    testContext = {};
+    testContext.selected = "metal";
+    testContext.onChange = jest.fn();
     testContext.component = mount(
       <Dropdown
         items={dropdownItems}
@@ -59,13 +59,23 @@ describe("Dropdown Component", () => {
     expect(testContext.onChange).toHaveBeenCalled();
   });
 
-  it("toggles `isOpen` on click", () => {
+  it("toggles dropdown on click", () => {
     const wrapper = testContext.component.find("div").first();
 
     wrapper.simulate("click");
-    expect(testContext.component.state("isOpen")).toBeTruthy();
+    expect(
+      testContext.component
+        .find("div")
+        .first()
+        .hasClass("dropdown__wrapper--open")
+    ).toEqual(true);
 
     wrapper.simulate("click");
-    expect(testContext.component.state("isOpen")).toBeFalsy();
+    expect(
+      testContext.component
+        .find("div")
+        .first()
+        .hasClass("dropdown__wrapper--open")
+    ).toEqual(false);
   });
 });


### PR DESCRIPTION
This PR converts the `Dropdown` component from class to function component.

I wasn't sure if I should've created an issue before, but since there weren't any already there, I took the liberty to open the PR directly. If this works for you, I'd be happy to convert other components as well! :)