### PR TITLE
refactor(components/toolbar-item): convert to functional component

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ make setup
 make run
 ```
 
+> Note: make sure you're using node <14
+
 Then visit http://localhost:8080/#/ on your browser.
 
 To run local tests:
@@ -45,20 +47,17 @@ make test
 
 Megadraft depends on [Sass](http://sass-lang.com/) to build style assets.
 
-
 ## Importing the default styles
 
 Megadraft ships with a default styling available at this location in the installed package: node_modules/megadraft/dist/css/megadraft.css.
 
-
 ## Documentation
 
-* [Overview & Usage][docs-overview-and-usage]
-* [Customization][docs-customization]
-* [Custom Entities][docs-custom-entities]
-* [Plugins][docs-plugins]
-* [Saving & Loading][docs-saving-loading]
-
+- [Overview & Usage][docs-overview-and-usage]
+- [Customization][docs-customization]
+- [Custom Entities][docs-custom-entities]
+- [Plugins][docs-plugins]
+- [Saving & Loading][docs-saving-loading]
 
 ## Plugins
 
@@ -73,11 +72,9 @@ Development of Megadraft happens in the open on GitHub, and we are grateful to t
 
 Read our [contributing guide](CONTRIBUTING.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to Megadraft.
 
-
 ## License
 
 Megadraft is licensed under the [MIT license](LICENSE).
-
 
 ## Third Party
 
@@ -87,7 +84,6 @@ under [CC0 license](https://stocksnap.io/license).
 
 The Landing page uses a Megadeth picture by [Ted Van Pelt](https://flic.kr/p/7Pr94f)
 licensed under [CC-BY](https://creativecommons.org/licenses/by/2.0/).
-
 
 [plugin-generator]: https://github.com/globocom/generator-megadraft-plugin
 [docs-overview-and-usage]: http://globocom.github.io/megadraft/#/docs/overview

--- a/src/components/ToolbarItem.js
+++ b/src/components/ToolbarItem.js
@@ -4,45 +4,47 @@
  * License: MIT
  */
 
-import React, { Component } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import classNames from "classnames";
-
 import Separator from "./Separator";
 
-export default class ToolbarItem extends Component {
-  constructor(props) {
-    super(props);
-  }
+export default function ToolbarItem({ item, active, toggle }) {
+  const Icon = item.icon;
+  const className = classNames("toolbar__item", {
+    "toolbar__item--active": active
+  });
 
-  toggleAction(action) {
-    if (action.toggle) {
-      action.toggle(!action.active);
+  function toggleAction() {
+    if (toggle) {
+      toggle(!active);
     }
   }
 
-  render() {
-    const Icon = this.props.item.icon;
-
-    if (this.props.item.type == "separator") {
-      return <Separator />;
-    }
-
-    const className = classNames("toolbar__item", {
-      "toolbar__item--active": this.props.active
-    });
-
-    return (
-      <li className={className}>
-        <button
-          onClick={() => {
-            this.toggleAction(this.props);
-          }}
-          type="button"
-          className="toolbar__button"
-        >
-          <Icon />
-        </button>
-      </li>
-    );
+  if (item.type == "separator") {
+    return <Separator />;
   }
+
+  return (
+    <li className={className}>
+      <button
+        onClick={() => toggleAction()}
+        type="button"
+        className="toolbar__button"
+      >
+        <Icon />
+      </button>
+    </li>
+  );
 }
+
+ToolbarItem.propTypes = {
+  item: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    label: PropTypes.string,
+    icon: PropTypes.func.isRequired,
+    style: PropTypes.string
+  }),
+  active: PropTypes.bool,
+  toggle: PropTypes.func
+};


### PR DESCRIPTION
This PR converts the `ToolbarItem` component from class to function component and declares its PropTypes.

I've also updated the README to make it explicit in which node version you should be after having some trouble running the project locally.
