### PR TITLE
Remove unused "focus" method inside component body

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -300,10 +300,6 @@ export default class MegadraftEditor extends Component {
     return true;
   }
 
-  focus() {
-    this.draftEl.focus();
-  }
-
   setReadOnly(readOnly) {
     this.setState({ readOnly });
   }


### PR DESCRIPTION
## Related Issue
Unused methods of React components should be removed

## Proposed Changes

  - Remove unused "focus" method inside component body
