### PR TITLE
fix: cancel current entity if toolbar position changes

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -140,6 +140,8 @@ export default class Toolbar extends Component {
             },
             arrowStyle: selectionCoords.arrowStyle
           });
+
+          this.cancelEntity();
         }
       }
     );


### PR DESCRIPTION
## Related Issue
#378 

It seems like a needed fix, is not the expected behaviour.

## Proposed Changes

- Cancel current entity when toolbar position changes;

cc @marcelometal 
