### PR TITLE
Use optional chain expression in components

### DIFF
--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -41,8 +41,8 @@ class ErrorBoundary extends Component {
         ? "Something went wrong in component '{{type}}'. {{error}}"
         : "Something went wrong with the component type.";
       const text = replaceData(i18n[errorMsg], {
-        type: type && type.toString(),
-        error: this.state.error && this.state.error.toString()
+        type: type?.toString(),
+        error: this.state.error?.toString()
       });
       return (
         <CommonBlock {...this.props} actions={this.actions}>

--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -403,7 +403,7 @@ export default class MegadraftEditor extends Component {
         };
 
         const input = control.querySelector("[type=text]");
-        input && input.focus();
+        input?.focus();
 
         control.scrollIntoView({ block: "center" });
         window.scroll(0, window.pageYOffset - control.clientHeight / 2);

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -67,7 +67,7 @@ export default class Toolbar extends Component {
       case "custom": {
         key = "custom-" + position;
         toggle = () => item.action(this.props.editorState, this.props.onChange);
-        active = item.active && item.active(this.props.editorState);
+        active = item.active?.(this.props.editorState);
         break;
       }
       case "inline": {
@@ -239,7 +239,7 @@ export default class Toolbar extends Component {
         error: null
       },
       () => {
-        this.props.draft && this.props.draft.focus();
+        this.props.draft?.focus();
       }
     );
   }


### PR DESCRIPTION
## Proposed Changes

  - Preferable to use an optional chain expression, as it is more concise and easier to read. [SonarLint](https://rules.sonarsource.com/javascript/RSPEC-6582/)
