### PR TITLE
Replace declaration marked as deprecated (pageYOffset)

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -406,7 +406,7 @@ export default class MegadraftEditor extends Component {
         input && input.focus();
 
         control.scrollIntoView({ block: "center" });
-        window.scroll(0, window.pageYOffset - control.clientHeight / 2);
+        window.scroll(0, window.scrollY - control.clientHeight / 2);
 
         swapEffect();
 


### PR DESCRIPTION
## Related Issue
'pageYOffset' is deprecated.

## Proposed Changes

  - This is a legacy alias of scrollY, it should be replaced with it.
