### PR TITLE
Fix - new test: should not render modal when isOpen is false

### DIFF
--- a/tests/components/PluginsModal_test.js
+++ b/tests/components/PluginsModal_test.js
@@ -64,7 +64,16 @@ describe("PluginsModal", () => {
       },
       onAction
     );
-
+    
+  it("should not render modal when isOpen is false", () => {
+    const component = mountComponent({
+      isOpen: false
+    });
+  
+    // Check if the Modal has not been rendered
+    expect(component.find("Modal").exists()).toBe(false);
+  });
+  
     const { onCloseRequest } = component.find("Modal").props();
     onCloseRequest();
     expect(toggleModalVisibility).toHaveBeenCalled();


### PR DESCRIPTION
Added a new test to ensure the modal is closed when the isOpen prop is set to false. This would help check the conditional rendering behavior of the modal.

What we are testing: Whether the PluginsModal component does not render the modal when the isOpen property is false.
What we expect: That the modal is not rendered, so the test checks if Modal does not exist (exists() returns false).