### PR TITLE
feat: modernize deprecated React lifecycle methods

### DIFF
--- a/src/components/MegadraftEditor.js
+++ b/src/components/MegadraftEditor.js
@@ -138,12 +138,6 @@ export default class MegadraftEditor extends Component {
     return pluginsByType;
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (this.props.readOnly !== nextProps.readOnly) {
-      this.setState({ readOnly: nextProps.readOnly });
-    }
-  }
-
   onChange(editorState) {
     this.props.onChange(editorState);
   }
@@ -377,7 +371,12 @@ export default class MegadraftEditor extends Component {
     clearTimeout(this.blurTimeoutID);
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
+    // Handle readOnly prop changes
+    if (this.props.readOnly !== prevProps.readOnly) {
+      this.setState({ readOnly: this.props.readOnly });
+    }
+
     if (this.state.swapUp || this.state.swapDown) {
       const swapFunction = this.state.swapUp ? swapDataUp : swapDataDown;
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -163,16 +163,14 @@ export default class Toolbar extends Component {
     }
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
+    const prevContentState = prevProps.editorState.getCurrentContent();
     const currentContentState = this.props.editorState.getCurrentContent();
-    const newContentState = nextProps.editorState.getCurrentContent();
 
-    if (currentContentState === newContentState) {
+    if (prevContentState === currentContentState) {
       this.shouldUpdatePos = true;
     }
-  }
 
-  componentDidUpdate() {
     if (this.shouldUpdatePos) {
       this.handleSetToolbar();
     }


### PR DESCRIPTION
# Modernize deprecated React lifecycle methods

## Summary
This PR modernizes deprecated React lifecycle methods to improve compatibility with current and future React versions and eliminate deprecation warnings.

## Changes Made
- Replace `UNSAFE_componentWillReceiveProps` with `componentDidUpdate` in MegadraftEditor
- Replace `UNSAFE_componentWillReceiveProps` with `componentDidUpdate` in Toolbar  
- Consolidate lifecycle logic into existing `componentDidUpdate` methods
- Maintain backward compatibility and existing functionality
- Remove React deprecation warnings

## Why This Change?
- `UNSAFE_componentWillReceiveProps` has been deprecated since React 16.3
- These methods will be removed in future React versions
- Modern lifecycle methods provide better performance and predictability
- Eliminates console warnings in development

## Testing
- [x] Code passes ESLint checks
- [x] No breaking changes to existing functionality
- [x] Maintains same component behavior

## Compatibility
- ✅ Backward compatible
- ✅ No API changes
- ✅ Same functionality preserved

Fixes compatibility with current and future React versions

## Related Issue
Part of ongoing modernization efforts for React best practices

## Type of Change
- [x] Bug fix (removes deprecation warnings)
- [x] Code improvement/refactoring
- [ ] New feature
- [ ] Breaking change
