### PR TITLE
fix: replace string ref with React.createRef() in Toolbar component

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -32,6 +32,7 @@ export default class Toolbar extends Component {
       link: "",
       error: null
     };
+    this.toolbarWrapperRef = React.createRef();
     this.renderButton = this.renderButton.bind(this);
     this.cancelEntity = this.cancelEntity.bind(this);
     this.removeEntity = this.removeEntity.bind(this);
@@ -306,7 +307,7 @@ export default class Toolbar extends Component {
       <div
         className={toolbarClass}
         style={this.state.position}
-        ref="toolbarWrapper"
+        ref={this.toolbarWrapperRef}
       >
         <div style={{ position: "absolute", bottom: 0 }}>
           <div


### PR DESCRIPTION
## Related Issue
Fixes #373

## Proposed Changes

  - Replace deprecated string ref `"toolbarWrapper"` in `Toolbar.js` with `React.createRef()`
  - Update constructor to initialize `toolbarWrapperRef`
  - Use `ref={this.toolbarWrapperRef}` in the Toolbar render method
  - All tests pass and no new warnings are introduced
